### PR TITLE
Fix voting timer and allow voting until admin ends it (#61)

### DIFF
--- a/packages/client/src/components/MotionCard.vue
+++ b/packages/client/src/components/MotionCard.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
 const emit = defineEmits<(e: "click", motionId: number) => void>();
 
 // Use countdown timer composable
-const { remainingTimeString, isTimeUrgent, isExpired } = useCountdownTimer({
+const { remainingTimeString, isTimeUrgent, isOvertime } = useCountdownTimer({
 	getVotingEndsAt: () =>
 		props.motion.votingEndsAt === null
 			? null
@@ -27,7 +27,7 @@ function handleClick(): void {
 <template>
 	<div
 		class="motion-card"
-		:class="{ urgent: isUrgent, expired: isExpired }"
+		:class="{ urgent: isUrgent, overtime: isOvertime }"
 		@click="handleClick"
 	>
 		<div class="motion-header">
@@ -78,10 +78,9 @@ function handleClick(): void {
 	border-color: #e0a800;
 }
 
-.motion-card.expired {
-	opacity: 0.7;
-	border-color: #dc3545;
-	background: #fff5f5;
+.motion-card.overtime {
+	border-color: #e65100;
+	background: #fff3e0;
 }
 
 .motion-header {
@@ -150,11 +149,7 @@ function handleClick(): void {
 	font-size: 0.9rem;
 }
 
-.motion-card.expired .vote-prompt {
-	color: #dc3545;
-}
-
-.motion-card.expired .vote-prompt::before {
-	content: "Voting closed - ";
+.motion-card.overtime .vote-prompt {
+	color: #e65100;
 }
 </style>

--- a/packages/client/src/views/admin/MotionDetail.vue
+++ b/packages/client/src/views/admin/MotionDetail.vue
@@ -95,7 +95,7 @@ const canEdit = computed(() => {
 });
 
 // Use countdown timer composable
-const { remainingTimeString, isTimeUrgent } = useCountdownTimer({
+const { remainingTimeString, isTimeUrgent, isOvertime } = useCountdownTimer({
 	getVotingEndsAt: () => {
 		if (motion.value?.status !== MotionStatus.VotingActive) {
 			return null;
@@ -105,7 +105,10 @@ const { remainingTimeString, isTimeUrgent } = useCountdownTimer({
 			return new Date(motion.value.endOverride);
 		}
 
-		const startTime = new Date(motion.value.updatedAt);
+		if (motion.value.votingStartedAt === null) {
+			return null;
+		}
+		const startTime = new Date(motion.value.votingStartedAt);
 		const durationMs =
 			motion.value.plannedDuration * SECONDS_PER_MINUTE * MS_PER_SECOND;
 		return new Date(startTime.getTime() + durationMs);
@@ -668,7 +671,7 @@ watch(
 						<span
 							v-if="motion.status === MotionStatus.VotingActive"
 							class="time-remaining-badge"
-							:class="{ urgent: isTimeUrgent }"
+							:class="{ urgent: isTimeUrgent, overtime: isOvertime }"
 						>
 							{{ remainingTimeString }}
 						</span>
@@ -1447,6 +1450,10 @@ watch(
 .time-remaining-badge.urgent {
 	background: #f44336;
 	animation: pulse 1s infinite;
+}
+
+.time-remaining-badge.overtime {
+	background: #ff9800;
 }
 
 @keyframes pulse {

--- a/packages/server/src/services/vote-service.ts
+++ b/packages/server/src/services/vote-service.ts
@@ -170,9 +170,9 @@ export async function getMotionForVoting(
 						motionRow.planned_duration * MILLISECONDS_PER_MINUTE,
 				));
 
-	// Determine if voting is still open
-	const now = new Date();
-	const votingTimeExpired = votingEndsAt !== null && now >= votingEndsAt;
+	// Determine if voting is still open based on motion status
+	// Note: votingEndsAt is informational (planned duration) - voting remains
+	// open until an admin explicitly changes the status to voting_complete
 	const isVotingActive = motionRow.status === "voting_active";
 
 	// Determine voting eligibility and reason
@@ -188,9 +188,6 @@ export async function getMotionForVoting(
 	} else if (!isVotingActive) {
 		canVote = false;
 		votingEndedReason = "not_active";
-	} else if (votingTimeExpired) {
-		canVote = false;
-		votingEndedReason = "voting_ended";
 	}
 
 	return {
@@ -271,9 +268,8 @@ function validateVoteChoices(
  * 1. Motion exists and is voting_active
  * 2. User hasn't already voted
  * 3. User is in the voting pool
- * 4. Voting time hasn't expired
- * 5. Choice count doesn't exceed seat_count (unless abstaining)
- * 6. All choice IDs belong to this motion
+ * 4. Choice count doesn't exceed seat_count (unless abstaining)
+ * 5. All choice IDs belong to this motion
  */
 export async function castVote(
 	userId: string,


### PR DESCRIPTION
- Fix admin views to use votingStartedAt instead of updatedAt for timer
- Replace expired state with overtime state showing "Over by Xm Xs"
- Remove server-side time-expired check so voting stays open until admin explicitly changes status to voting_complete
- Update countdown timer composable with overtime tracking