### PR TITLE
Improve motion create/edit pages (#64)

### DIFF
--- a/packages/client/src/views/admin/MotionCreate.vue
+++ b/packages/client/src/views/admin/MotionCreate.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
-import { useRouter } from "vue-router";
-import { createMotion, getPools } from "../../services/api";
+import { ref, computed, onMounted, onUnmounted } from "vue";
+import { useRouter, onBeforeRouteLeave } from "vue-router";
+import { createChoice, createMotion, getPools } from "../../services/api";
 import type { Pool } from "@mcdc-convention-voting/shared";
 
 const props = defineProps<{
@@ -19,6 +19,9 @@ const DEFAULT_SEAT_COUNT = 1;
 const DEFAULT_DURATION = 5;
 const MIN_DURATION = 1;
 const MIN_SEAT_COUNT = 1;
+const FIRST_INDEX = 0;
+const ADJACENT_OFFSET = 1;
+const EMPTY_ARRAY_LENGTH = 0;
 
 const pools = ref<Pool[]>([]);
 const loadingPools = ref(false);
@@ -31,8 +34,27 @@ const formData = ref({
 	votingPoolId: EMPTY_STRING,
 });
 
+const pendingChoices = ref<string[]>([]);
+const newChoiceName = ref(EMPTY_STRING);
+const choiceError = ref<string | null>(null);
+
 const saving = ref(false);
+const saved = ref(false);
 const error = ref<string | null>(null);
+
+const isDirty = computed((): boolean => {
+	if (saved.value) {
+		return false;
+	}
+	return (
+		formData.value.name !== EMPTY_STRING ||
+		formData.value.description !== EMPTY_STRING ||
+		formData.value.plannedDuration !== DEFAULT_DURATION ||
+		formData.value.seatCount !== DEFAULT_SEAT_COUNT ||
+		formData.value.votingPoolId !== EMPTY_STRING ||
+		pendingChoices.value.length > EMPTY_ARRAY_LENGTH
+	);
+});
 
 async function loadPools(): Promise<void> {
 	loadingPools.value = true;
@@ -44,6 +66,39 @@ async function loadPools(): Promise<void> {
 	} finally {
 		loadingPools.value = false;
 	}
+}
+
+function addPendingChoice(): void {
+	if (newChoiceName.value.trim() === EMPTY_STRING) {
+		choiceError.value = "Choice name is required.";
+		return;
+	}
+	choiceError.value = null;
+	pendingChoices.value.push(newChoiceName.value.trim());
+	newChoiceName.value = EMPTY_STRING;
+}
+
+function removePendingChoice(index: number): void {
+	pendingChoices.value.splice(index, ADJACENT_OFFSET);
+}
+
+function movePendingChoiceUp(index: number): void {
+	if (index === FIRST_INDEX) {
+		return;
+	}
+	const previousIndex = index - ADJACENT_OFFSET;
+	const items = pendingChoices.value;
+	[items[previousIndex], items[index]] = [items[index], items[previousIndex]];
+}
+
+function movePendingChoiceDown(index: number): void {
+	const lastIndex = pendingChoices.value.length - ADJACENT_OFFSET;
+	if (index >= lastIndex) {
+		return;
+	}
+	const nextIndex = index + ADJACENT_OFFSET;
+	const items = pendingChoices.value;
+	[items[index], items[nextIndex]] = [items[nextIndex], items[index]];
 }
 
 async function handleSubmit(): Promise<void> {
@@ -84,8 +139,20 @@ async function handleSubmit(): Promise<void> {
 			}),
 		};
 
-		await createMotion(motionData);
-		void router.push(`/admin/meetings/${props.meetingId}/motions`);
+		const response = await createMotion(motionData);
+		const newMotionId = response.data.id;
+
+		// Create pending choices sequentially
+		for (const choiceName of pendingChoices.value) {
+			// eslint-disable-next-line no-await-in-loop -- Sequential inserts required for choices
+			await createChoice({
+				motionId: newMotionId,
+				name: choiceName,
+			});
+		}
+
+		saved.value = true;
+		void router.push(`/admin/motions/${String(newMotionId)}`);
 	} catch (err) {
 		error.value =
 			err instanceof Error ? err.message : "Failed to create motion";
@@ -98,8 +165,32 @@ function cancel(): void {
 	void router.push(`/admin/meetings/${props.meetingId}/motions`);
 }
 
+function handleBeforeUnload(e: BeforeUnloadEvent): void {
+	if (isDirty.value) {
+		e.preventDefault();
+	}
+}
+
+onBeforeRouteLeave(() => {
+	if (isDirty.value) {
+		// eslint-disable-next-line no-alert -- User-facing confirmation for unsaved changes
+		const answer = window.confirm(
+			"You have unsaved changes. Are you sure you want to leave?",
+		);
+		if (!answer) {
+			return false;
+		}
+	}
+	return true;
+});
+
 onMounted(() => {
 	void loadPools();
+	window.addEventListener("beforeunload", handleBeforeUnload);
+});
+
+onUnmounted(() => {
+	window.removeEventListener("beforeunload", handleBeforeUnload);
 });
 </script>
 
@@ -182,6 +273,73 @@ onMounted(() => {
 				<p class="field-description">
 					Override the meeting's quorum pool for this specific motion
 				</p>
+			</div>
+
+			<!-- Choices Section -->
+			<div class="form-group choices-group">
+				<label>Choices</label>
+				<p class="field-description">
+					Define the options voters can choose from. Choices can also be added
+					after creation.
+				</p>
+
+				<div v-if="choiceError" class="error-inline">
+					{{ choiceError }}
+				</div>
+
+				<div v-if="pendingChoices.length === 0" class="empty-choices">
+					No choices added yet.
+				</div>
+
+				<ul v-else class="choices-list">
+					<li v-for="(choice, index) in pendingChoices" :key="index">
+						<span class="choice-name">{{ choice }}</span>
+						<div class="choice-actions">
+							<button
+								type="button"
+								class="btn btn-small"
+								:disabled="index === 0"
+								title="Move up"
+								@click="movePendingChoiceUp(index)"
+							>
+								&uarr;
+							</button>
+							<button
+								type="button"
+								class="btn btn-small"
+								:disabled="index >= pendingChoices.length - 1"
+								title="Move down"
+								@click="movePendingChoiceDown(index)"
+							>
+								&darr;
+							</button>
+							<button
+								type="button"
+								class="btn btn-small btn-danger"
+								title="Delete"
+								@click="removePendingChoice(index)"
+							>
+								Delete
+							</button>
+						</div>
+					</li>
+				</ul>
+
+				<div class="add-choice-form">
+					<input
+						v-model="newChoiceName"
+						type="text"
+						placeholder="Enter choice name"
+						@keydown.enter.prevent="addPendingChoice"
+					/>
+					<button
+						type="button"
+						class="btn btn-primary btn-small"
+						@click="addPendingChoice"
+					>
+						Add Choice
+					</button>
+				</div>
 			</div>
 
 			<div class="form-actions">
@@ -302,5 +460,81 @@ h2 {
 
 .btn-secondary:hover:not(:disabled) {
 	background-color: #616161;
+}
+
+.btn-small {
+	padding: 0.25rem 0.5rem;
+	font-size: 0.8125rem;
+}
+
+.btn-danger {
+	background-color: #dc3545;
+	color: white;
+}
+
+.btn-danger:hover:not(:disabled) {
+	background-color: #c82333;
+}
+
+.error-inline {
+	padding: 0.75rem;
+	margin-bottom: 1rem;
+	background-color: #ffebee;
+	color: #c62828;
+	border-radius: 4px;
+	font-size: 0.875rem;
+}
+
+.choices-group {
+	margin-top: 1.5rem;
+}
+
+.empty-choices {
+	padding: 1rem;
+	color: #666;
+	font-style: italic;
+}
+
+.choices-list {
+	list-style: none;
+	padding: 0;
+	margin: 0 0 1.5rem 0;
+}
+
+.choices-list li {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 0.75rem;
+	border: 1px solid #e0e0e0;
+	border-radius: 4px;
+	margin-bottom: 0.5rem;
+}
+
+.choice-name {
+	font-weight: 500;
+}
+
+.choice-actions {
+	display: flex;
+	gap: 0.25rem;
+}
+
+.add-choice-form {
+	display: flex;
+	gap: 0.5rem;
+}
+
+.add-choice-form input {
+	flex: 1;
+	padding: 0.5rem 0.75rem;
+	border: 1px solid #e0e0e0;
+	border-radius: 4px;
+	font-size: 0.875rem;
+}
+
+.add-choice-form input:focus {
+	outline: none;
+	border-color: #1976d2;
 }
 </style>


### PR DESCRIPTION
- Remove 'Start Voting' button from motion detail page (remains on list page)
- Allow choices to be added during motion creation with reorder/delete
- Redirect to motion detail page after creation instead of list
- Add unsaved changes warning on both create and edit pages