### PR TITLE
Add View Results button for completed motions (#62)

### DIFF
--- a/packages/client/src/views/admin/MotionList.vue
+++ b/packages/client/src/views/admin/MotionList.vue
@@ -526,6 +526,13 @@ watch(currentPage, () => {
 									End Voting
 								</button>
 								<button
+									v-if="motion.status === MotionStatus.VotingComplete"
+									class="btn btn-small btn-info"
+									@click="editMotion(motion.id)"
+								>
+									View Results
+								</button>
+								<button
 									v-if="canStartVoting(motion.status)"
 									class="btn btn-small btn-danger"
 									@click="requestDelete(motion.id)"
@@ -785,6 +792,15 @@ watch(currentPage, () => {
 
 .btn-danger:hover {
 	background-color: #c82333;
+}
+
+.btn-info {
+	background-color: #17a2b8;
+	color: white;
+}
+
+.btn-info:hover {
+	background-color: #138496;
 }
 
 .btn:disabled {


### PR DESCRIPTION
## Summary
- Adds a "View Results" button in the Actions column for motions with status "Complete"
- Button navigates to the motion detail page (same destination as clicking the motion name)
- Uses a cyan/teal `.btn-info` style to differentiate from other action buttons

## Test plan
- [ ] Navigate to the motions list page
- [ ] Verify the "View Results" button appears for motions with "Complete" status
- [ ] Click the button and verify it navigates to the motion detail page
- [ ] Verify no button appears for "Not Started" or "Voting Active" status motions (those have their own buttons)

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)