### PR TITLE
Display abstention statistics and add voter explanation (#67)

### DIFF
--- a/packages/client/src/views/admin/MotionDetail.vue
+++ b/packages/client/src/views/admin/MotionDetail.vue
@@ -1031,6 +1031,15 @@ watch(
 									{{ detailedResults.participationRate.toFixed(1) }}%
 								</span>
 							</div>
+
+							<div class="summary-stat">
+								<span class="stat-label">Abstentions:</span>
+								<span class="stat-value">
+									{{ detailedResults.abstentionCount }} ({{
+										detailedResults.abstentionPercentage.toFixed(1)
+									}}%)
+								</span>
+							</div>
 						</div>
 
 						<!-- Choice Results -->

--- a/packages/client/src/views/voter/MotionDetail.vue
+++ b/packages/client/src/views/voter/MotionDetail.vue
@@ -391,6 +391,11 @@ onUnmounted((): void => {
 						</span>
 						<span class="choice-name">Abstain</span>
 					</div>
+					<p class="abstain-note">
+						Selecting Abstain will be treated the same as if you did not vote on
+						the motion, and will only impact the participation records and
+						statistics.
+					</p>
 				</div>
 
 				<!-- Selection summary -->
@@ -724,6 +729,13 @@ onUnmounted((): void => {
 .abstain-item.selected .choice-checkbox {
 	background: #ff9800;
 	border-color: #ff9800;
+}
+
+.abstain-note {
+	margin: 0.5rem 0 0 0;
+	font-size: 0.8125rem;
+	color: #666;
+	font-style: italic;
 }
 
 .selection-summary {

--- a/packages/client/src/views/watcher/WatcherMeetingReport.vue
+++ b/packages/client/src/views/watcher/WatcherMeetingReport.vue
@@ -138,6 +138,7 @@ onMounted(() => {
 								<th>Status</th>
 								<th>Voting Pool</th>
 								<th>Votes Cast</th>
+								<th>Abstentions</th>
 								<th>Started</th>
 								<th>Ended</th>
 								<th>Results</th>
@@ -160,6 +161,13 @@ onMounted(() => {
 								</td>
 								<td>{{ motion.votingPoolName || "—" }}</td>
 								<td>{{ motion.totalVotesCast }}</td>
+								<td>
+									{{
+										motion.status === MotionStatus.VotingComplete
+											? motion.totalAbstentions
+											: ""
+									}}
+								</td>
 								<td>{{ formatDate(motion.votingStartedAt) }}</td>
 								<td>{{ formatDate(motion.votingEndedAt) }}</td>
 								<td class="results-cell">

--- a/packages/client/src/views/watcher/WatcherMotionReport.vue
+++ b/packages/client/src/views/watcher/WatcherMotionReport.vue
@@ -267,6 +267,10 @@ onMounted(() => {
 						<div class="stat-value">{{ participationPercentage }}%</div>
 						<div class="stat-label">Participation Rate</div>
 					</div>
+					<div v-if="motion.totalAbstentions !== null" class="stat-card">
+						<div class="stat-value">{{ motion.totalAbstentions }}</div>
+						<div class="stat-label">Abstentions</div>
+					</div>
 				</div>
 
 				<!-- Choice Results -->

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -845,6 +845,7 @@ export interface WatcherMotionDetail {
 	endOverride: Date | null;
 	// Vote counts (null if not yet started)
 	totalVotesCast: number | null;
+	totalAbstentions: number | null;
 	// Results (only for completed motions)
 	result: WatcherMotionResult | null;
 }


### PR DESCRIPTION
## Summary
- Add explanatory note under Abstain option explaining that selecting Abstain only impacts participation records/statistics
- Display abstention count and percentage in admin motion results
- Add `totalAbstentions` field to `WatcherMotionDetail` type
- Include abstention count in watcher service response
- Display abstention count in watcher motion report
- Add Abstentions column to watcher meeting report summaries (only shows value when voting is complete)

**Note:** The backend already correctly excludes abstentions from choice percentages - this change makes that visible to users.

## Test plan
- [ ] Log in as voter, view a motion - verify explanatory note appears below Abstain option
- [ ] Log in as admin, view completed motion results - verify abstention count and percentage displayed
- [ ] Log in as watcher, view completed motion report - verify abstention count displayed
- [ ] Log in as watcher, view meeting report - verify Abstentions column shows values only for completed motions

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)