### PR TITLE
Add pool-based filtering to password generation

### DIFF
--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -6,6 +6,7 @@ import type {
 	CreateUserRequest,
 	BulkPasswordResponse,
 	PasswordGenerationResult,
+	GeneratePasswordsRequest,
 	Pool,
 	CreatePoolRequest,
 	UpdatePoolRequest,
@@ -309,15 +310,20 @@ export async function enableUser(id: string): Promise<ApiResponse<User>> {
 }
 
 /**
- * Generate passwords for all users without passwords
+ * Generate passwords for users with optional filtering
+ * @param options - Optional filters (poolId, onlyNullPasswords)
  */
-export async function generatePasswords(): Promise<
-	ApiResponse<BulkPasswordResponse>
-> {
+export async function generatePasswords(
+	options?: GeneratePasswordsRequest,
+): Promise<ApiResponse<BulkPasswordResponse>> {
 	return await apiRequest<ApiResponse<BulkPasswordResponse>>(
 		`${API_PREFIX}/admin/users/generate-passwords`,
 		{
 			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify(options ?? {}),
 		},
 	);
 }

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -65,6 +65,7 @@ import type {
 	UserListResponse,
 	BulkPasswordResponse,
 	PasswordResetResponse,
+	GeneratePasswordsRequest,
 	CreatePoolRequest,
 	UpdatePoolRequest,
 	PoolListResponse,
@@ -355,13 +356,26 @@ adminRouter.post(
 
 /**
  * POST /api/admin/users/generate-passwords
- * Generate passwords for all users without passwords
+ * Generate passwords for users with optional filtering
+ * Body: { poolId?: number, onlyNullPasswords?: boolean }
  */
 adminRouter.post(
 	"/users/generate-passwords",
 	async (req: Request, res: Response) => {
 		try {
-			const results = await generatePasswordsForUsers();
+			// Extract optional filter parameters from request body
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
+			const body: GeneratePasswordsRequest = req.body;
+			const poolId = typeof body.poolId === "number" ? body.poolId : undefined;
+			const onlyNullPasswords =
+				typeof body.onlyNullPasswords === "boolean"
+					? body.onlyNullPasswords
+					: undefined;
+
+			const results = await generatePasswordsForUsers({
+				poolId,
+				onlyNullPasswords,
+			});
 
 			const response: BulkPasswordResponse = {
 				results,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -144,6 +144,14 @@ export interface BulkPasswordResponse {
 }
 
 /**
+ * Request for bulk password generation with optional filters
+ */
+export interface GeneratePasswordsRequest {
+	poolId?: number; // Only generate for users in this pool
+	onlyNullPasswords?: boolean; // Only generate for users without existing passwords
+}
+
+/**
  * Response from password reset operation
  */
 export interface PasswordResetResponse {


### PR DESCRIPTION
## Summary
- Add pool dropdown to filter password generation by specific pool
- Add checkbox to generate passwords only for users without existing passwords
- Update backend to accept filter parameters and build conditional SQL queries
- Enables preserving existing passwords when uploading new CSV files

Closes #72

## Test plan
- [ ] Navigate to Password Generation page as admin
- [ ] Test generating passwords with "All Pools" selected
- [ ] Test generating passwords for a specific pool only
- [ ] Test "Only users without existing passwords" checkbox
- [ ] Verify confirmation modal shows correct filter description
- [ ] Verify CSV download contains only filtered users

🤖 Generated with [Claude Code](https://claude.com/claude-code)