### PR TITLE
Add under-vote warning in vote confirmation modal

### DIFF
--- a/packages/client/src/views/voter/MotionDetail.vue
+++ b/packages/client/src/views/voter/MotionDetail.vue
@@ -131,6 +131,19 @@ const selectedChoices = computed((): Choice[] => {
 	);
 });
 
+// Check if user is under-voting (selecting fewer than allowed when more are available)
+const isUnderVoting = computed((): boolean => {
+	if (motion.value === null || isAbstaining.value) {
+		return false;
+	}
+	const selectedCount = selectedChoiceIds.value.length;
+	const maxAllowed = motion.value.seatCount;
+	const totalChoices = motion.value.choices.length;
+
+	// Under-voting if: selected < max allowed AND selected < total available choices
+	return selectedCount < maxAllowed && selectedCount < totalChoices;
+});
+
 // Get reason message for why user cannot vote
 const cannotVoteMessage = computed((): string => {
 	if (motion.value === null) {
@@ -436,6 +449,17 @@ onUnmounted((): void => {
 							{{ choice.name }}
 						</li>
 					</ul>
+					<div
+						v-if="isUnderVoting && motion !== null"
+						class="under-vote-warning"
+					>
+						<p>
+							<strong>Note:</strong> You have selected
+							{{ selectedChoiceIds.length }} choice(s), but you may select up to
+							{{ Math.min(motion.seatCount, motion.choices.length) }}. To change
+							your selections, click Cancel.
+						</p>
+					</div>
 					<p class="warning-text">
 						This action cannot be undone. Your vote is final.
 					</p>
@@ -807,6 +831,20 @@ onUnmounted((): void => {
 	color: #ff9800;
 	font-size: 0.9rem;
 	font-style: italic;
+}
+
+.under-vote-warning {
+	margin: 1rem 0;
+	padding: 0.75rem 1rem;
+	background: #fff3e0;
+	border-left: 4px solid #ff9800;
+	border-radius: 4px;
+}
+
+.under-vote-warning p {
+	margin: 0;
+	color: #e65100;
+	font-size: 0.9rem;
 }
 
 .submit-error {


### PR DESCRIPTION
## Summary
- Add warning in the "Confirm Your Vote" modal when voters select fewer choices than allowed
- Warning only appears when more choices are available to select (not when all choices are selected)
- Provides clear guidance: "To change your selections, click Cancel."

Closes #68

## Test plan
- [ ] Log in as a voter with a motion that has multiple seats (e.g., 3 seats, 5 choices)
- [ ] Select 1-2 choices (fewer than allowed) → Click Submit → Warning should appear
- [ ] Select all available choices → Click Submit → No warning
- [ ] Select max allowed (e.g., 3 of 3 seats) → Click Submit → No warning  
- [ ] Abstain → Click Submit → No warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)