### PR TITLE
Change Seat(s) to Selection(s) for UI consistency

### DIFF
--- a/packages/client/src/components/MotionCard.vue
+++ b/packages/client/src/components/MotionCard.vue
@@ -41,7 +41,7 @@ function handleClick(): void {
 		</div>
 		<div class="motion-meta">
 			<span class="meeting-name">{{ motion.meetingName }}</span>
-			<span class="seat-count">{{ motion.seatCount }} seat(s)</span>
+			<span class="seat-count">{{ motion.seatCount }} selection(s)</span>
 		</div>
 		<div class="motion-action">
 			<span class="vote-prompt">Click to vote</span>

--- a/packages/client/src/views/admin/MotionCreate.vue
+++ b/packages/client/src/views/admin/MotionCreate.vue
@@ -247,7 +247,7 @@ onUnmounted(() => {
 					min="1"
 				/>
 				<p class="field-description">
-					Number of seats to elect (for elections) or 1 for yes/no votes
+					Number of selections allowed (or 1 for yes/no votes)
 				</p>
 			</div>
 

--- a/packages/client/src/views/admin/MotionList.vue
+++ b/packages/client/src/views/admin/MotionList.vue
@@ -426,7 +426,7 @@ watch(currentPage, () => {
 						<th>Name</th>
 						<th>Description</th>
 						<th>Duration</th>
-						<th>Seats</th>
+						<th>Selections</th>
 						<th>Pool</th>
 						<th>Status</th>
 						<th>Votes</th>

--- a/packages/client/src/views/voter/MotionDetail.vue
+++ b/packages/client/src/views/voter/MotionDetail.vue
@@ -343,7 +343,7 @@ onUnmounted((): void => {
 					<span class="info-value">{{ motion.meetingName }}</span>
 				</div>
 				<div class="info-item">
-					<span class="info-label">Seats</span>
+					<span class="info-label">Selections</span>
 					<span class="info-value">{{ motion.seatCount }}</span>
 				</div>
 				<div class="info-item">

--- a/packages/client/src/views/watcher/WatcherMotionReport.vue
+++ b/packages/client/src/views/watcher/WatcherMotionReport.vue
@@ -188,7 +188,7 @@ onMounted(() => {
 						}}</span>
 					</div>
 					<div class="detail-item">
-						<span class="detail-label">Seats to Elect</span>
+						<span class="detail-label">Selections</span>
 						<span class="detail-value">{{ motion.seatCount }}</span>
 					</div>
 					<div class="detail-item">


### PR DESCRIPTION
## Summary
- Update UI terminology from "Seat(s)" to "Selection(s)" for consistency
- Changes made in 5 files across voter, admin, and watcher views

Closes #63

## Changes
| Location | Before | After |
|----------|--------|-------|
| MotionCard (voter dashboard) | `X seat(s)` | `X selection(s)` |
| Voter motion detail | `Seats` | `Selections` |
| Watcher motion report | `Seats to Elect` | `Selections` |
| Admin motion create | `Number of seats to elect...` | `Number of selections allowed...` |
| Admin motion list | Table header `Seats` | `Selections` |

## Test plan
- [ ] Voter dashboard: Check motion cards show "selection(s)"
- [ ] Voter motion detail: Info panel shows "Selections"
- [ ] Admin motion list: Table header shows "Selections"
- [ ] Admin motion create: Field description updated
- [ ] Watcher motion report: Shows "Selections"

🤖 Generated with [Claude Code](https://claude.com/claude-code)