### PR TITLE
Add pool filter and search to admin user list (#83)

### DIFF
--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -231,12 +231,13 @@ export async function uploadUsersCSV(
 }
 
 /**
- * Get paginated list of users with optional search
+ * Get paginated list of users with optional search and pool filter
  */
 export async function getUsers(
 	page = DEFAULT_PAGE,
 	limit = DEFAULT_PAGE_LIMIT,
 	search?: string,
+	poolId?: number,
 ): Promise<PaginatedResponse<User>> {
 	const params = new URLSearchParams({
 		page: String(page),
@@ -244,6 +245,9 @@ export async function getUsers(
 	});
 	if (search !== undefined && search.trim() !== "") {
 		params.set("search", search.trim());
+	}
+	if (poolId !== undefined) {
+		params.set("poolId", String(poolId));
 	}
 	return await apiRequest<PaginatedResponse<User>>(
 		`${API_PREFIX}/admin/users?${params.toString()}`,

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -167,7 +167,7 @@ adminRouter.post(
 
 /**
  * GET /api/admin/users
- * List all users with pagination and optional search
+ * List all users with pagination and optional search/pool filter
  */
 adminRouter.get("/users", async (req: Request, res: Response) => {
 	try {
@@ -181,10 +181,20 @@ adminRouter.get("/users", async (req: Request, res: Response) => {
 				: String(DEFAULT_LIMIT);
 		const searchParam =
 			typeof req.query.search === "string" ? req.query.search : undefined;
+		const poolIdParam =
+			typeof req.query.poolId === "string" ? req.query.poolId : undefined;
+		const poolIdParsed =
+			poolIdParam === undefined
+				? undefined
+				: parseInt(poolIdParam, DECIMAL_RADIX);
+		const poolId =
+			poolIdParsed === undefined || isNaN(poolIdParsed)
+				? undefined
+				: poolIdParsed;
 		const page = Number.parseInt(pageParam, DECIMAL_RADIX);
 		const limit = Number.parseInt(limitParam, DECIMAL_RADIX);
 
-		const { users, total } = await listUsers(page, limit, searchParam);
+		const { users, total } = await listUsers(page, limit, searchParam, poolId);
 
 		const response: UserListResponse = {
 			data: users,


### PR DESCRIPTION
## Summary

- Add pool filter dropdown to admin user list with three options:
  - **All Users**: Shows all users regardless of pool
  - **Pool-specific**: Shows only users in the selected pool
  - **None**: Shows no users (default on page load for faster loading)
- Search functionality works within the selected filter
- Clear button only clears the search query, not the pool filter
- Added hint text reminding admins that search is constrained to the current filter

## Test plan

- [ ] Navigate to Admin > Users
- [ ] Verify initial state shows "Select a pool to view users" with no users displayed
- [ ] Select "All Users" and verify all users are shown
- [ ] Select a specific pool and verify only users in that pool are shown
- [ ] Use search within a pool filter and verify results are limited to that pool
- [ ] Click Clear and verify search is cleared but pool filter remains
- [ ] Select "None" and verify no users are displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)