### PR TITLE
Add Missing Pool Definitions admin page (#89)

### DIFF
--- a/packages/client/src/router/index.ts
+++ b/packages/client/src/router/index.ts
@@ -18,6 +18,7 @@ import PoolUpload from "../views/admin/PoolUpload.vue";
 import PoolCreate from "../views/admin/PoolCreate.vue";
 import PoolEdit from "../views/admin/PoolEdit.vue";
 import PoolUsers from "../views/admin/PoolUsers.vue";
+import MissingPools from "../views/admin/MissingPools.vue";
 import MeetingList from "../views/admin/MeetingList.vue";
 import MeetingCreate from "../views/admin/MeetingCreate.vue";
 import MeetingEdit from "../views/admin/MeetingEdit.vue";
@@ -130,6 +131,11 @@ export const router = createRouter({
 					path: "pools/create",
 					name: "PoolCreate",
 					component: PoolCreate,
+				},
+				{
+					path: "pools/missing",
+					name: "MissingPools",
+					component: MissingPools,
 				},
 				{
 					path: "pools/:id/edit",

--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -1065,3 +1065,87 @@ export async function deleteUserById(id: string): Promise<ApiResponse<void>> {
 		},
 	);
 }
+
+/**
+ * Pending Pool Key Management API Functions
+ */
+
+interface PendingPoolKey {
+	poolKey: string;
+	userCount: number;
+	firstSeenAt: Date;
+}
+
+interface PendingPoolKeyListResponse {
+	data: PendingPoolKey[];
+	pagination: {
+		page: number;
+		limit: number;
+		total: number;
+		totalPages: number;
+	};
+}
+
+interface ResolvePendingPoolResponse {
+	usersUpdated: number;
+	pool: Pool;
+}
+
+/**
+ * Get pending (missing) pool keys with user counts
+ */
+export async function getPendingPoolKeys(
+	page = DEFAULT_PAGE,
+	limit = DEFAULT_PAGE_LIMIT,
+): Promise<PendingPoolKeyListResponse> {
+	return await apiRequest<PendingPoolKeyListResponse>(
+		`${API_PREFIX}/admin/pools/pending?page=${page}&limit=${limit}`,
+	);
+}
+
+/**
+ * Resolve pending pool key by creating a new pool
+ */
+export async function resolvePendingPoolByCreating(request: {
+	poolKey: string;
+	poolName: string;
+	description?: string;
+}): Promise<ApiResponse<ResolvePendingPoolResponse>> {
+	return await apiRequest<ApiResponse<ResolvePendingPoolResponse>>(
+		`${API_PREFIX}/admin/pools/pending/create`,
+		{
+			method: "POST",
+			body: JSON.stringify(request),
+		},
+	);
+}
+
+/**
+ * Resolve pending pool key by remapping users to existing pool
+ */
+export async function resolvePendingPoolByRemapping(request: {
+	pendingPoolKey: string;
+	targetPoolId: number;
+}): Promise<ApiResponse<ResolvePendingPoolResponse>> {
+	return await apiRequest<ApiResponse<ResolvePendingPoolResponse>>(
+		`${API_PREFIX}/admin/pools/pending/remap`,
+		{
+			method: "POST",
+			body: JSON.stringify(request),
+		},
+	);
+}
+
+/**
+ * Delete pending pool key without resolving
+ */
+export async function deletePendingPoolKey(
+	poolKey: string,
+): Promise<ApiResponse<{ deletedCount: number }>> {
+	return await apiRequest<ApiResponse<{ deletedCount: number }>>(
+		`${API_PREFIX}/admin/pools/pending/${encodeURIComponent(poolKey)}`,
+		{
+			method: "DELETE",
+		},
+	);
+}

--- a/packages/client/src/views/AdminLayout.vue
+++ b/packages/client/src/views/AdminLayout.vue
@@ -57,6 +57,9 @@ const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
 					<RouterLink to="/admin/pools/create" class="dropdown-link">
 						Create Pool
 					</RouterLink>
+					<RouterLink to="/admin/pools/missing" class="dropdown-link">
+						Missing Pools
+					</RouterLink>
 				</NavDropdown>
 				<RouterLink to="/admin/meetings" class="nav-link">
 					Meetings
@@ -134,6 +137,13 @@ const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
 						@click="closeNav"
 					>
 						Create Pool
+					</RouterLink>
+					<RouterLink
+						to="/admin/pools/missing"
+						class="mobile-nav-link"
+						@click="closeNav"
+					>
+						Missing Pools
 					</RouterLink>
 				</div>
 

--- a/packages/client/src/views/admin/MissingPools.vue
+++ b/packages/client/src/views/admin/MissingPools.vue
@@ -1,0 +1,613 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from "vue";
+import {
+	getPendingPoolKeys,
+	getPools,
+	resolvePendingPoolByCreating,
+	resolvePendingPoolByRemapping,
+	deletePendingPoolKey,
+} from "../../services/api";
+import TablePagination from "../../components/TablePagination.vue";
+import type { Pool } from "@mcdc-convention-voting/shared";
+
+// Constants
+const ITEMS_PER_PAGE = 50;
+const INITIAL_PAGE = 1;
+const INITIAL_TOTAL = 0;
+const EMPTY_STRING = "";
+const NO_ITEMS = 0;
+const MAX_POOLS_FOR_DROPDOWN = 1000;
+
+// Pending pool key interface (matches API response)
+interface PendingPoolKey {
+	poolKey: string;
+	userCount: number;
+	firstSeenAt: Date;
+}
+
+// State
+const pendingKeys = ref<PendingPoolKey[]>([]);
+const pools = ref<Pool[]>([]);
+const loading = ref(false);
+const error = ref<string | null>(null);
+const currentPage = ref(INITIAL_PAGE);
+const totalItems = ref(INITIAL_TOTAL);
+
+// Modal state - Create Pool
+const showCreateModal = ref(false);
+const createModalKey = ref(EMPTY_STRING);
+const createPoolName = ref(EMPTY_STRING);
+const createDescription = ref(EMPTY_STRING);
+const createLoading = ref(false);
+
+// Modal state - Remap to Existing Pool
+const showRemapModal = ref(false);
+const remapModalKey = ref(EMPTY_STRING);
+const selectedPoolId = ref<number | null>(null);
+const remapLoading = ref(false);
+
+// Modal state - Delete Confirmation
+const showDeleteModal = ref(false);
+const deleteModalKey = ref(EMPTY_STRING);
+const deleteLoading = ref(false);
+
+// Success message
+const successMessage = ref<string | null>(null);
+
+const totalPages = computed(() => Math.ceil(totalItems.value / ITEMS_PER_PAGE));
+
+async function loadData(): Promise<void> {
+	loading.value = true;
+	error.value = null;
+	successMessage.value = null;
+
+	try {
+		const [pendingResponse, poolsResponse] = await Promise.all([
+			getPendingPoolKeys(currentPage.value, ITEMS_PER_PAGE),
+			getPools(INITIAL_PAGE, MAX_POOLS_FOR_DROPDOWN),
+		]);
+
+		pendingKeys.value = pendingResponse.data;
+		totalItems.value = pendingResponse.pagination.total;
+		pools.value = poolsResponse.data.filter((p) => !p.isDisabled);
+	} catch (err) {
+		error.value = err instanceof Error ? err.message : "Failed to load data";
+	} finally {
+		loading.value = false;
+	}
+}
+
+// Create Pool Modal
+function openCreateModal(poolKey: string): void {
+	createModalKey.value = poolKey;
+	createPoolName.value = poolKey; // Pre-fill with key as default name
+	createDescription.value = EMPTY_STRING;
+	showCreateModal.value = true;
+}
+
+function closeCreateModal(): void {
+	showCreateModal.value = false;
+	createModalKey.value = EMPTY_STRING;
+	createPoolName.value = EMPTY_STRING;
+	createDescription.value = EMPTY_STRING;
+}
+
+async function handleCreatePool(): Promise<void> {
+	if (createPoolName.value.trim() === EMPTY_STRING) {
+		error.value = "Pool name is required";
+		return;
+	}
+
+	createLoading.value = true;
+	error.value = null;
+
+	try {
+		const trimmedDescription = createDescription.value.trim();
+		const result = await resolvePendingPoolByCreating({
+			poolKey: createModalKey.value,
+			poolName: createPoolName.value.trim(),
+			description: trimmedDescription === "" ? undefined : trimmedDescription,
+		});
+
+		successMessage.value = `Created pool "${result.data?.pool.poolName}" and associated ${result.data?.usersUpdated} users`;
+		closeCreateModal();
+		await loadData();
+	} catch (err) {
+		error.value = err instanceof Error ? err.message : "Failed to create pool";
+	} finally {
+		createLoading.value = false;
+	}
+}
+
+// Remap Modal
+function openRemapModal(poolKey: string): void {
+	remapModalKey.value = poolKey;
+	selectedPoolId.value = null;
+	showRemapModal.value = true;
+}
+
+function closeRemapModal(): void {
+	showRemapModal.value = false;
+	remapModalKey.value = EMPTY_STRING;
+	selectedPoolId.value = null;
+}
+
+async function handleRemap(): Promise<void> {
+	if (selectedPoolId.value === null) {
+		error.value = "Please select a pool";
+		return;
+	}
+
+	remapLoading.value = true;
+	error.value = null;
+
+	try {
+		const result = await resolvePendingPoolByRemapping({
+			pendingPoolKey: remapModalKey.value,
+			targetPoolId: selectedPoolId.value,
+		});
+
+		successMessage.value = `Remapped ${result.data?.usersUpdated} users to pool "${result.data?.pool.poolName}"`;
+		closeRemapModal();
+		await loadData();
+	} catch (err) {
+		error.value = err instanceof Error ? err.message : "Failed to remap users";
+	} finally {
+		remapLoading.value = false;
+	}
+}
+
+// Delete Modal
+function openDeleteModal(poolKey: string): void {
+	deleteModalKey.value = poolKey;
+	showDeleteModal.value = true;
+}
+
+function closeDeleteModal(): void {
+	showDeleteModal.value = false;
+	deleteModalKey.value = EMPTY_STRING;
+}
+
+async function handleDelete(): Promise<void> {
+	deleteLoading.value = true;
+	error.value = null;
+
+	try {
+		const result = await deletePendingPoolKey(deleteModalKey.value);
+		successMessage.value = `Deleted ${result.data?.deletedCount} pending records for "${deleteModalKey.value}"`;
+		closeDeleteModal();
+		await loadData();
+	} catch (err) {
+		error.value = err instanceof Error ? err.message : "Failed to delete";
+	} finally {
+		deleteLoading.value = false;
+	}
+}
+
+function goToPage(page: number): void {
+	currentPage.value = page;
+	void loadData();
+}
+
+function formatDate(date: Date): string {
+	return new Date(date).toLocaleDateString();
+}
+
+onMounted(() => {
+	void loadData();
+});
+</script>
+
+<template>
+	<div class="missing-pools">
+		<div class="header">
+			<h2>Missing Pool Definitions</h2>
+			<p class="description">
+				These pool keys were used during CSV user imports but don't match any
+				existing pools. Resolve each by creating a new pool or remapping users
+				to an existing pool.
+			</p>
+		</div>
+
+		<div v-if="successMessage" class="success">
+			{{ successMessage }}
+			<button class="dismiss" @click="successMessage = null">&times;</button>
+		</div>
+
+		<div v-if="error" class="error">
+			{{ error }}
+		</div>
+
+		<div v-if="loading" class="loading">Loading...</div>
+
+		<div v-else-if="pendingKeys.length === NO_ITEMS" class="empty">
+			No missing pool definitions. All pool keys from CSV imports match existing
+			pools.
+		</div>
+
+		<div v-else class="table-container">
+			<table class="pending-table">
+				<thead>
+					<tr>
+						<th>Pool Key</th>
+						<th>Users Count</th>
+						<th>First Seen</th>
+						<th>Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr v-for="pending in pendingKeys" :key="pending.poolKey">
+						<td class="pool-key">{{ pending.poolKey }}</td>
+						<td class="user-count">{{ pending.userCount }}</td>
+						<td>{{ formatDate(pending.firstSeenAt) }}</td>
+						<td class="actions-cell">
+							<button
+								class="btn btn-small btn-primary"
+								@click="openCreateModal(pending.poolKey)"
+							>
+								Create Pool
+							</button>
+							<button
+								class="btn btn-small btn-secondary"
+								@click="openRemapModal(pending.poolKey)"
+							>
+								Remap to Existing
+							</button>
+							<button
+								class="btn btn-small btn-danger"
+								@click="openDeleteModal(pending.poolKey)"
+							>
+								Discard
+							</button>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+
+			<TablePagination
+				:current-page="currentPage"
+				:total-pages="totalPages"
+				:total-items="totalItems"
+				@page-change="goToPage"
+			/>
+		</div>
+
+		<!-- Create Pool Modal -->
+		<div v-if="showCreateModal" class="modal" @click="closeCreateModal">
+			<div class="modal-content" @click.stop>
+				<h3>Create New Pool</h3>
+				<p>
+					Create a new pool with key "<strong>{{ createModalKey }}</strong
+					>" and associate all users.
+				</p>
+
+				<div class="form-group">
+					<label for="poolName"
+						>Pool Name <span class="required">*</span></label
+					>
+					<input
+						id="poolName"
+						v-model="createPoolName"
+						type="text"
+						placeholder="Display name for the pool"
+					/>
+				</div>
+
+				<div class="form-group">
+					<label for="description">Description</label>
+					<textarea
+						id="description"
+						v-model="createDescription"
+						rows="2"
+						placeholder="Optional description"
+					/>
+				</div>
+
+				<div class="modal-actions">
+					<button
+						class="btn btn-primary"
+						:disabled="createLoading"
+						@click="handleCreatePool"
+					>
+						{{ createLoading ? "Creating..." : "Create Pool" }}
+					</button>
+					<button class="btn btn-secondary" @click="closeCreateModal">
+						Cancel
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<!-- Remap Modal -->
+		<div v-if="showRemapModal" class="modal" @click="closeRemapModal">
+			<div class="modal-content" @click.stop>
+				<h3>Remap to Existing Pool</h3>
+				<p>
+					Users with key "<strong>{{ remapModalKey }}</strong
+					>" will be added to the selected pool.
+				</p>
+
+				<div class="form-group">
+					<label for="targetPool"
+						>Select Pool <span class="required">*</span></label
+					>
+					<select id="targetPool" v-model="selectedPoolId">
+						<option :value="null" disabled>-- Select a pool --</option>
+						<option v-for="pool in pools" :key="pool.id" :value="pool.id">
+							{{ pool.poolName }} ({{ pool.poolKey }})
+						</option>
+					</select>
+				</div>
+
+				<div class="modal-actions">
+					<button
+						class="btn btn-primary"
+						:disabled="remapLoading || selectedPoolId === null"
+						@click="handleRemap"
+					>
+						{{ remapLoading ? "Remapping..." : "Remap Users" }}
+					</button>
+					<button class="btn btn-secondary" @click="closeRemapModal">
+						Cancel
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<!-- Delete Confirmation Modal -->
+		<div v-if="showDeleteModal" class="modal" @click="closeDeleteModal">
+			<div class="modal-content" @click.stop>
+				<h3>Discard Pending Pool Key</h3>
+				<p>
+					Are you sure you want to discard all pending records for "<strong>{{
+						deleteModalKey
+					}}</strong
+					>"? Users will not be associated with any pool for this key.
+				</p>
+
+				<div class="modal-actions">
+					<button
+						class="btn btn-danger"
+						:disabled="deleteLoading"
+						@click="handleDelete"
+					>
+						{{ deleteLoading ? "Deleting..." : "Yes, Discard" }}
+					</button>
+					<button class="btn btn-secondary" @click="closeDeleteModal">
+						Cancel
+					</button>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<style scoped>
+.missing-pools {
+	max-width: 1200px;
+	margin: 0 auto;
+}
+
+.header {
+	margin-bottom: 2rem;
+}
+
+.header h2 {
+	margin: 0 0 0.5rem 0;
+	color: #2c3e50;
+}
+
+.description {
+	color: #666;
+	margin: 0;
+}
+
+.success {
+	background-color: #d4edda;
+	color: #155724;
+	padding: 1rem;
+	border-radius: 4px;
+	margin-bottom: 1rem;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+
+.success .dismiss {
+	background: none;
+	border: none;
+	font-size: 1.25rem;
+	cursor: pointer;
+	color: #155724;
+}
+
+.error {
+	background-color: #fee;
+	color: #c33;
+	padding: 1rem;
+	border-radius: 4px;
+	margin-bottom: 1rem;
+}
+
+.loading {
+	text-align: center;
+	padding: 2rem;
+	color: #666;
+}
+
+.empty {
+	text-align: center;
+	padding: 3rem;
+	color: #666;
+	background-color: white;
+	border-radius: 8px;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.table-container {
+	background-color: white;
+	border-radius: 8px;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+	overflow: hidden;
+}
+
+.pending-table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.pending-table th {
+	background-color: #f8f9fa;
+	padding: 1rem;
+	text-align: left;
+	font-weight: 600;
+	color: #2c3e50;
+	border-bottom: 2px solid #dee2e6;
+}
+
+.pending-table td {
+	padding: 1rem;
+	border-bottom: 1px solid #dee2e6;
+}
+
+.pending-table tbody tr:hover {
+	background-color: #f8f9fa;
+}
+
+.pool-key {
+	font-family: monospace;
+	color: #d35400;
+	font-weight: 500;
+}
+
+.user-count {
+	font-weight: 600;
+}
+
+.actions-cell {
+	display: flex;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+}
+
+.btn {
+	padding: 0.5rem 1rem;
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 0.875rem;
+	font-weight: 500;
+	transition: all 0.2s;
+}
+
+.btn-small {
+	padding: 0.25rem 0.75rem;
+	font-size: 0.8125rem;
+}
+
+.btn-primary {
+	background-color: #007bff;
+	color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+	background-color: #0056b3;
+}
+
+.btn-secondary {
+	background-color: #6c757d;
+	color: white;
+}
+
+.btn-secondary:hover:not(:disabled) {
+	background-color: #545b62;
+}
+
+.btn-danger {
+	background-color: #dc3545;
+	color: white;
+}
+
+.btn-danger:hover:not(:disabled) {
+	background-color: #c82333;
+}
+
+.btn:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+/* Modal styles matching PoolList.vue */
+.modal {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: rgba(0, 0, 0, 0.5);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 1000;
+}
+
+.modal-content {
+	background-color: white;
+	padding: 2rem;
+	border-radius: 8px;
+	max-width: 500px;
+	width: 90%;
+	box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.modal-content h3 {
+	margin: 0 0 1rem 0;
+	color: #2c3e50;
+}
+
+.modal-content p {
+	margin: 0 0 1.5rem 0;
+	color: #666;
+	line-height: 1.5;
+}
+
+.form-group {
+	margin-bottom: 1rem;
+}
+
+.form-group label {
+	display: block;
+	margin-bottom: 0.5rem;
+	font-weight: 500;
+	color: #2c3e50;
+}
+
+.required {
+	color: #c62828;
+}
+
+.form-group input,
+.form-group textarea,
+.form-group select {
+	width: 100%;
+	padding: 0.75rem;
+	border: 1px solid #e0e0e0;
+	border-radius: 4px;
+	font-size: 1rem;
+	font-family: inherit;
+}
+
+.form-group input:focus,
+.form-group textarea:focus,
+.form-group select:focus {
+	outline: none;
+	border-color: #1976d2;
+}
+
+.modal-actions {
+	display: flex;
+	gap: 1rem;
+	justify-content: flex-end;
+	margin-top: 1.5rem;
+}
+</style>

--- a/packages/client/src/views/admin/UserUpload.vue
+++ b/packages/client/src/views/admin/UserUpload.vue
@@ -8,6 +8,7 @@ const router = useRouter();
 // Constants
 const NO_FILES = 0;
 const NO_ERRORS = 0;
+const NO_WARNINGS = 0;
 
 const selectedFile = ref<File | null>(null);
 const uploading = ref(false);
@@ -16,6 +17,7 @@ const uploadResult = ref<{
 	success: number;
 	failed: number;
 	errors: Array<{ row: number; voterId: string; error: string }>;
+	warnings?: Array<{ voterId: string; warning: string }>;
 } | null>(null);
 
 // Status message during upload
@@ -198,6 +200,37 @@ function goToUsers(): void {
 				</table>
 			</div>
 
+			<div
+				v-if="
+					uploadResult.warnings !== undefined &&
+					uploadResult.warnings.length > NO_WARNINGS
+				"
+				class="warning-list"
+			>
+				<h4>Warnings:</h4>
+				<p class="warning-description">
+					The following users were created but had issues with pool assignments.
+					Invalid pool keys were skipped.
+				</p>
+				<table class="warning-table">
+					<thead>
+						<tr>
+							<th>Voter ID</th>
+							<th>Warning</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr
+							v-for="(uploadWarning, index) in uploadResult.warnings"
+							:key="index"
+						>
+							<td>{{ uploadWarning.voterId }}</td>
+							<td>{{ uploadWarning.warning }}</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
 			<button class="btn btn-secondary" @click="goToUsers">
 				Go to User List
 			</button>
@@ -374,6 +407,44 @@ h2 {
 	background-color: #f5f5f5;
 	font-weight: 600;
 	color: #2c3e50;
+}
+
+.warning-list {
+	margin: 1.5rem 0;
+}
+
+.warning-list h4 {
+	color: #f57c00;
+	margin-bottom: 0.5rem;
+}
+
+.warning-description {
+	color: #666;
+	font-size: 0.9rem;
+	margin-bottom: 1rem;
+}
+
+.warning-table {
+	width: 100%;
+	border-collapse: collapse;
+	margin-bottom: 1.5rem;
+}
+
+.warning-table th,
+.warning-table td {
+	padding: 0.75rem;
+	text-align: left;
+	border-bottom: 1px solid #ffe0b2;
+}
+
+.warning-table th {
+	background-color: #fff3e0;
+	font-weight: 600;
+	color: #e65100;
+}
+
+.warning-table tr:hover {
+	background-color: #fff8e1;
 }
 
 .download-template {

--- a/packages/server/src/database/migrations/0011-create-pending-pool-keys.sql
+++ b/packages/server/src/database/migrations/0011-create-pending-pool-keys.sql
@@ -1,0 +1,26 @@
+-- Create pending_pool_keys table to track invalid pool keys from CSV imports
+-- These are pool keys that users attempted to use but which don't exist in the pools table
+
+CREATE TABLE pending_pool_keys (
+  id SERIAL PRIMARY KEY,
+  pool_key VARCHAR(255) NOT NULL,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+  -- Ensure each user-poolkey combination is unique
+  UNIQUE (user_id, pool_key)
+);
+
+-- Add indexes for common query patterns
+-- Index on pool_key for grouping/aggregation queries
+CREATE INDEX idx_pending_pool_keys_pool_key ON pending_pool_keys(pool_key);
+
+-- Index on user_id for user-specific lookups and CASCADE deletes
+CREATE INDEX idx_pending_pool_keys_user_id ON pending_pool_keys(user_id);
+
+-- Add comments for documentation
+COMMENT ON TABLE pending_pool_keys IS 'Tracks pool keys from CSV imports that did not match existing pools';
+COMMENT ON COLUMN pending_pool_keys.id IS 'Unique identifier';
+COMMENT ON COLUMN pending_pool_keys.pool_key IS 'The pool key string that was attempted but not found';
+COMMENT ON COLUMN pending_pool_keys.user_id IS 'Reference to the user who had this invalid pool key';
+COMMENT ON COLUMN pending_pool_keys.created_at IS 'When this pending key was recorded';

--- a/packages/server/src/services/pending-pool-service.ts
+++ b/packages/server/src/services/pending-pool-service.ts
@@ -1,0 +1,238 @@
+/**
+ * Pending pool key management service
+ * Tracks and resolves pool keys from CSV imports that don't match existing pools
+ */
+import { db, withTransaction } from "../database/db.js";
+import { createPool, addUserToPool, getPoolById } from "./pool-service.js";
+import type { TinyPg } from "tinypg";
+import type {
+	PendingPoolKey,
+	ResolvePendingPoolResponse,
+} from "@mcdc-convention-voting/shared";
+
+// Array index constants
+const FIRST_ROW = 0;
+const EMPTY_ARRAY_LENGTH = 0;
+
+// Pagination constants
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 50;
+const PAGE_OFFSET_ADJUSTMENT = 1;
+
+// Radix for parseInt
+const DECIMAL_RADIX = 10;
+
+/**
+ * Record pending pool keys for a user during CSV import
+ * Called when setUserPools() encounters invalid pool keys
+ *
+ * @param userId - The user ID
+ * @param invalidPoolKeys - Array of pool key strings that were not found
+ * @param existingTx - Optional transaction context
+ */
+export async function recordPendingPoolKeys(
+	userId: string,
+	invalidPoolKeys: string[],
+	existingTx?: TinyPg,
+): Promise<void> {
+	if (invalidPoolKeys.length === EMPTY_ARRAY_LENGTH) {
+		return;
+	}
+
+	const doRecord = async (tx: TinyPg): Promise<void> => {
+		// Insert pending pool keys, ignoring duplicates
+		await tx.query(
+			`INSERT INTO pending_pool_keys (user_id, pool_key)
+       SELECT :userId, unnest(:poolKeys::text[])
+       ON CONFLICT (user_id, pool_key) DO NOTHING`,
+			{ userId, poolKeys: invalidPoolKeys },
+		);
+	};
+
+	if (existingTx === undefined) {
+		await withTransaction(doRecord);
+	} else {
+		await doRecord(existingTx);
+	}
+}
+
+/**
+ * List pending pool keys with aggregated user counts
+ */
+export async function listPendingPoolKeys(
+	page = DEFAULT_PAGE,
+	limit = DEFAULT_LIMIT,
+): Promise<{ pendingKeys: PendingPoolKey[]; total: number }> {
+	const offset = (page - PAGE_OFFSET_ADJUSTMENT) * limit;
+
+	// Get total count of distinct pool keys
+	const countResult = await db.query<{ count: string }>(
+		"SELECT COUNT(DISTINCT pool_key) as count FROM pending_pool_keys",
+	);
+	const total = parseInt(countResult.rows[FIRST_ROW].count, DECIMAL_RADIX);
+
+	// Get paginated pending keys with user counts
+	const result = await db.query<{
+		pool_key: string;
+		user_count: string;
+		first_seen_at: Date;
+	}>(
+		`SELECT
+       pool_key,
+       COUNT(user_id)::text as user_count,
+       MIN(created_at) as first_seen_at
+     FROM pending_pool_keys
+     GROUP BY pool_key
+     ORDER BY COUNT(user_id) DESC, pool_key ASC
+     LIMIT :limit OFFSET :offset`,
+		{ limit, offset },
+	);
+
+	const pendingKeys = result.rows.map((row) => ({
+		poolKey: row.pool_key,
+		userCount: parseInt(row.user_count, DECIMAL_RADIX),
+		firstSeenAt: row.first_seen_at,
+	}));
+
+	return { pendingKeys, total };
+}
+
+/**
+ * Get users associated with a specific pending pool key
+ */
+export async function getUsersForPendingPoolKey(
+	poolKey: string,
+	page = DEFAULT_PAGE,
+	limit = DEFAULT_LIMIT,
+): Promise<{ userIds: string[]; total: number }> {
+	const offset = (page - PAGE_OFFSET_ADJUSTMENT) * limit;
+
+	const countResult = await db.query<{ count: string }>(
+		"SELECT COUNT(*) as count FROM pending_pool_keys WHERE pool_key = :poolKey",
+		{ poolKey },
+	);
+	const total = parseInt(countResult.rows[FIRST_ROW].count, DECIMAL_RADIX);
+
+	const result = await db.query<{ user_id: string }>(
+		`SELECT user_id FROM pending_pool_keys
+     WHERE pool_key = :poolKey
+     ORDER BY created_at ASC
+     LIMIT :limit OFFSET :offset`,
+		{ poolKey, limit, offset },
+	);
+
+	return {
+		userIds: result.rows.map((row) => row.user_id),
+		total,
+	};
+}
+
+/**
+ * Resolve pending pool keys by creating a new pool and associating users
+ *
+ * @param poolKey - The pending pool key to resolve
+ * @param poolName - Display name for the new pool
+ * @param description - Optional description
+ */
+export async function resolvePendingByCreatingPool(
+	poolKey: string,
+	poolName: string,
+	description?: string,
+): Promise<ResolvePendingPoolResponse> {
+	return await withTransaction(async (tx) => {
+		// Create the new pool
+		const pool = await createPool({ poolKey, poolName, description });
+
+		// Get all users with this pending pool key
+		const usersResult = await tx.query<{ user_id: string }>(
+			"SELECT user_id FROM pending_pool_keys WHERE pool_key = :poolKey",
+			{ poolKey },
+		);
+
+		// Add each user to the new pool
+		for (const { user_id: userId } of usersResult.rows) {
+			// eslint-disable-next-line no-await-in-loop -- Sequential within transaction
+			await addUserToPool(pool.id, userId);
+		}
+
+		// Delete the pending pool key records
+		await tx.query("DELETE FROM pending_pool_keys WHERE pool_key = :poolKey", {
+			poolKey,
+		});
+
+		return {
+			usersUpdated: usersResult.rows.length,
+			pool,
+		};
+	});
+}
+
+/**
+ * Resolve pending pool keys by remapping users to an existing pool
+ *
+ * @param pendingPoolKey - The pending pool key to resolve
+ * @param targetPoolId - The existing pool to add users to
+ */
+export async function resolvePendingByRemapping(
+	pendingPoolKey: string,
+	targetPoolId: number,
+): Promise<ResolvePendingPoolResponse> {
+	return await withTransaction(async (tx) => {
+		// Verify target pool exists
+		const pool = await getPoolById(targetPoolId);
+
+		if (pool === null) {
+			throw new Error(`Pool with ID ${targetPoolId} not found`);
+		}
+
+		// Get all users with this pending pool key
+		const usersResult = await tx.query<{ user_id: string }>(
+			"SELECT user_id FROM pending_pool_keys WHERE pool_key = :pendingPoolKey",
+			{ pendingPoolKey },
+		);
+
+		// Add each user to the target pool (ON CONFLICT DO NOTHING handles existing associations)
+		for (const { user_id: userId } of usersResult.rows) {
+			// eslint-disable-next-line no-await-in-loop -- Sequential within transaction
+			await addUserToPool(pool.id, userId);
+		}
+
+		// Delete the pending pool key records
+		await tx.query(
+			"DELETE FROM pending_pool_keys WHERE pool_key = :pendingPoolKey",
+			{ pendingPoolKey },
+		);
+
+		return {
+			usersUpdated: usersResult.rows.length,
+			pool,
+		};
+	});
+}
+
+/**
+ * Delete all pending records for a specific pool key without resolving
+ * (Admin decided to ignore/discard these)
+ */
+export async function deletePendingPoolKey(poolKey: string): Promise<number> {
+	const result = await db.query<{ count: string }>(
+		`WITH deleted AS (
+       DELETE FROM pending_pool_keys WHERE pool_key = :poolKey
+       RETURNING *
+     )
+     SELECT COUNT(*)::text as count FROM deleted`,
+		{ poolKey },
+	);
+	return parseInt(result.rows[FIRST_ROW].count, DECIMAL_RADIX);
+}
+
+/**
+ * Check if a pool key is pending (has any records)
+ */
+export async function isPendingPoolKey(poolKey: string): Promise<boolean> {
+	const result = await db.query<{ exists: boolean }>(
+		"SELECT EXISTS(SELECT 1 FROM pending_pool_keys WHERE pool_key = :poolKey) as exists",
+		{ poolKey },
+	);
+	return result.rows[FIRST_ROW].exists;
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -264,6 +264,62 @@ export interface UpdatePoolRequest {
 export type PoolListResponse = PaginatedResponse<Pool>;
 
 /**
+ * Pending Pool Key Types
+ * Used for tracking invalid pool keys from CSV imports
+ */
+
+/**
+ * Pending pool key summary for admin view
+ * Represents a pool key that was used in CSV import but doesn't exist
+ *
+ * Database schema (pending_pool_keys table):
+ * - id: SERIAL PRIMARY KEY
+ * - pool_key: VARCHAR(255) NOT NULL
+ * - user_id: UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE
+ * - created_at: TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+ * - UNIQUE (user_id, pool_key)
+ *
+ * This interface represents aggregated data from the table.
+ *
+ * IMPORTANT: Keep this type in sync with database migrations
+ */
+export interface PendingPoolKey {
+	poolKey: string;
+	userCount: number;
+	firstSeenAt: Date;
+}
+
+/**
+ * Request to resolve pending pool keys by creating a new pool
+ */
+export interface ResolvePendingPoolCreateRequest {
+	poolKey: string;
+	poolName: string;
+	description?: string;
+}
+
+/**
+ * Request to resolve pending pool keys by remapping users to existing pool
+ */
+export interface ResolvePendingPoolRemapRequest {
+	pendingPoolKey: string;
+	targetPoolId: number;
+}
+
+/**
+ * Response from resolve pending pool operation
+ */
+export interface ResolvePendingPoolResponse {
+	usersUpdated: number;
+	pool: Pool;
+}
+
+/**
+ * Paginated response for pending pool keys
+ */
+export type PendingPoolKeyListResponse = PaginatedResponse<PendingPoolKey>;
+
+/**
  * Meeting Management Types
  */
 


### PR DESCRIPTION
## Summary

- Add admin view to identify and resolve pool keys from CSV imports that don't match existing pools
- Store invalid pool keys during CSV import in new `pending_pool_keys` table
- Provide three resolution actions: Create Pool, Remap to Existing, Discard
- Fix UserUpload.vue to display warnings from CSV imports that were previously hidden

## Changes

**Database:**
- New migration `0011-create-pending-pool-keys.sql` - stores invalid pool keys with user associations

**Backend:**
- New `pending-pool-service.ts` - manages pending pool key CRUD operations
- Modified `pool-service.ts` - records invalid keys during CSV import
- New API endpoints in `admin.ts`:
  - `GET /pools/pending` - list pending keys with user counts
  - `POST /pools/pending/create` - resolve by creating new pool
  - `POST /pools/pending/remap` - resolve by remapping to existing pool
  - `DELETE /pools/pending/:poolKey` - discard pending records

**Frontend:**
- New `MissingPools.vue` admin page with table and modal dialogs
- Updated `UserUpload.vue` to display import warnings
- Added navigation links in `AdminLayout.vue` (desktop and mobile)
- Added route in `router/index.ts`

**Shared:**
- Added types: `PendingPoolKey`, `ResolvePendingPoolCreateRequest`, `ResolvePendingPoolRemapRequest`, `ResolvePendingPoolResponse`

## Test plan

- [ ] Run migrations: `npm run migrate`
- [ ] Upload CSV with invalid pool keys via Users > Upload CSV
- [ ] Verify warnings are displayed after upload
- [ ] Navigate to Pools > Missing Pools
- [ ] Test "Create Pool" action - creates new pool and associates users
- [ ] Test "Remap to Existing" action - adds users to selected pool
- [ ] Test "Discard" action - removes pending records without creating pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)