### PR TITLE
Rename seat_count to selection_count (#32)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -179,6 +179,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -202,6 +203,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1468,6 +1470,7 @@
 			"integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -1542,6 +1545,7 @@
 			"integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.51.0",
 				"@typescript-eslint/types": "8.51.0",
@@ -2332,6 +2336,7 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -3206,6 +3211,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/dotenv": {
+			"version": "17.4.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+			"integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3549,6 +3566,7 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -6314,6 +6332,7 @@
 			"resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
 			"integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"pg-connection-string": "^2.9.1",
 				"pg-pool": "^3.10.1",
@@ -7850,6 +7869,7 @@
 			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "~0.27.0",
 				"get-tsconfig": "^4.7.5"
@@ -7993,6 +8013,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -8067,6 +8088,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"napi-postinstall": "^0.3.0"
 			},
@@ -8144,6 +8166,7 @@
 			"integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.4.4",
@@ -9749,6 +9772,7 @@
 			"integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",
@@ -9815,6 +9839,7 @@
 			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.26.tgz",
 			"integrity": "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vue/compiler-dom": "3.5.26",
 				"@vue/compiler-sfc": "3.5.26",
@@ -10334,6 +10359,7 @@
 				"@pdc/http-status-codes": "^1.0.1",
 				"bcrypt": "^6.0.0",
 				"csv-parse": "^6.1.0",
+				"dotenv": "^17.4.1",
 				"express": "^4.21.2",
 				"jsonwebtoken": "^9.0.3",
 				"multer": "^2.0.2",

--- a/packages/client/src/components/MotionCard.vue
+++ b/packages/client/src/components/MotionCard.vue
@@ -41,7 +41,7 @@ function handleClick(): void {
 		</div>
 		<div class="motion-meta">
 			<span class="meeting-name">{{ motion.meetingName }}</span>
-			<span class="seat-count">{{ motion.seatCount }} selection(s)</span>
+			<span class="seat-count">{{ motion.selectionCount }} selection(s)</span>
 		</div>
 		<div class="motion-action">
 			<span class="vote-prompt">Click to vote</span>

--- a/packages/client/src/views/admin/MotionCreate.vue
+++ b/packages/client/src/views/admin/MotionCreate.vue
@@ -15,10 +15,10 @@ const EMPTY_STRING = "";
 const ALL_POOLS_LIMIT = 1000;
 const INITIAL_PAGE = 1;
 const DECIMAL_RADIX = 10;
-const DEFAULT_SEAT_COUNT = 1;
+const DEFAULT_SELECTION_COUNT = 1;
 const DEFAULT_DURATION = 5;
 const MIN_DURATION = 1;
-const MIN_SEAT_COUNT = 1;
+const MIN_SELECTION_COUNT = 1;
 const FIRST_INDEX = 0;
 const ADJACENT_OFFSET = 1;
 const EMPTY_ARRAY_LENGTH = 0;
@@ -30,7 +30,7 @@ const formData = ref({
 	name: EMPTY_STRING,
 	description: EMPTY_STRING,
 	plannedDuration: DEFAULT_DURATION,
-	seatCount: DEFAULT_SEAT_COUNT,
+	selectionCount: DEFAULT_SELECTION_COUNT,
 	votingPoolId: EMPTY_STRING,
 });
 
@@ -50,7 +50,7 @@ const isDirty = computed((): boolean => {
 		formData.value.name !== EMPTY_STRING ||
 		formData.value.description !== EMPTY_STRING ||
 		formData.value.plannedDuration !== DEFAULT_DURATION ||
-		formData.value.seatCount !== DEFAULT_SEAT_COUNT ||
+		formData.value.selectionCount !== DEFAULT_SELECTION_COUNT ||
 		formData.value.votingPoolId !== EMPTY_STRING ||
 		pendingChoices.value.length > EMPTY_ARRAY_LENGTH
 	);
@@ -114,7 +114,7 @@ async function handleSubmit(): Promise<void> {
 		return;
 	}
 
-	if (formData.value.seatCount < MIN_SEAT_COUNT) {
+	if (formData.value.selectionCount < MIN_SELECTION_COUNT) {
 		error.value = "Selection count must be at least 1.";
 		return;
 	}
@@ -127,7 +127,7 @@ async function handleSubmit(): Promise<void> {
 			meetingId: meetingIdNum,
 			name: formData.value.name.trim(),
 			plannedDuration: formData.value.plannedDuration,
-			seatCount: formData.value.seatCount,
+			selectionCount: formData.value.selectionCount,
 			...(formData.value.description.trim() !== EMPTY_STRING && {
 				description: formData.value.description.trim(),
 			}),
@@ -236,13 +236,13 @@ onUnmounted(() => {
 			</div>
 
 			<div class="form-group">
-				<label for="seatCount">
+				<label for="selectionCount">
 					Selection Count
 					<span class="optional">(default: 1)</span>
 				</label>
 				<input
-					id="seatCount"
-					v-model.number="formData.seatCount"
+					id="selectionCount"
+					v-model.number="formData.selectionCount"
 					type="number"
 					min="1"
 				/>

--- a/packages/client/src/views/admin/MotionDetail.vue
+++ b/packages/client/src/views/admin/MotionDetail.vue
@@ -37,9 +37,9 @@ const DECIMAL_RADIX = 10;
 const FIRST_INDEX = 0;
 const ADJACENT_OFFSET = 1;
 const MIN_DURATION = 1;
-const MIN_SEAT_COUNT = 1;
+const MIN_SELECTION_COUNT = 1;
 const DEFAULT_DURATION = 5;
-const DEFAULT_SEAT_COUNT = 1;
+const DEFAULT_SELECTION_COUNT = 1;
 const STATS_POLL_INTERVAL_MS = 30000; // 30 seconds
 const MS_PER_SECOND = 1000;
 const SECONDS_PER_MINUTE = 60;
@@ -75,7 +75,7 @@ const formData = ref({
 	name: EMPTY_STRING,
 	description: EMPTY_STRING,
 	plannedDuration: DEFAULT_DURATION,
-	seatCount: DEFAULT_SEAT_COUNT,
+	selectionCount: DEFAULT_SELECTION_COUNT,
 	votingPoolId: EMPTY_STRING,
 });
 
@@ -83,7 +83,7 @@ const savedFormData = ref({
 	name: EMPTY_STRING,
 	description: EMPTY_STRING,
 	plannedDuration: DEFAULT_DURATION,
-	seatCount: DEFAULT_SEAT_COUNT,
+	selectionCount: DEFAULT_SELECTION_COUNT,
 	votingPoolId: EMPTY_STRING,
 });
 
@@ -110,7 +110,7 @@ const isDirty = computed((): boolean => {
 		formData.value.name !== savedFormData.value.name ||
 		formData.value.description !== savedFormData.value.description ||
 		formData.value.plannedDuration !== savedFormData.value.plannedDuration ||
-		formData.value.seatCount !== savedFormData.value.seatCount ||
+		formData.value.selectionCount !== savedFormData.value.selectionCount ||
 		formData.value.votingPoolId !== savedFormData.value.votingPoolId
 	);
 });
@@ -168,7 +168,7 @@ async function loadMotion(): Promise<void> {
 				name: data.name,
 				description: data.description ?? EMPTY_STRING,
 				plannedDuration: data.plannedDuration,
-				seatCount: data.seatCount,
+				selectionCount: data.selectionCount,
 				votingPoolId:
 					data.votingPoolId === null ? EMPTY_STRING : String(data.votingPoolId),
 			};
@@ -213,7 +213,7 @@ async function handleSubmit(): Promise<void> {
 		return;
 	}
 
-	if (formData.value.seatCount < MIN_SEAT_COUNT) {
+	if (formData.value.selectionCount < MIN_SELECTION_COUNT) {
 		error.value = "Selection count must be at least 1.";
 		return;
 	}
@@ -225,7 +225,7 @@ async function handleSubmit(): Promise<void> {
 		const trimmedDescription = formData.value.description.trim();
 		const motionData = {
 			plannedDuration: formData.value.plannedDuration,
-			seatCount: formData.value.seatCount,
+			selectionCount: formData.value.selectionCount,
 			description:
 				trimmedDescription === EMPTY_STRING ? undefined : trimmedDescription,
 			votingPoolId:
@@ -591,7 +591,7 @@ async function saveTitle(): Promise<void> {
 		await updateMotion(motionId, {
 			name: tempTitle.value.trim(),
 			plannedDuration: motion.value.plannedDuration,
-			seatCount: motion.value.seatCount,
+			selectionCount: motion.value.selectionCount,
 			description: motion.value.description ?? undefined,
 			votingPoolId: motion.value.votingPoolId ?? undefined,
 		});
@@ -768,10 +768,10 @@ watch(
 					</div>
 
 					<div class="form-group">
-						<label for="seatCount"> Selection Count </label>
+						<label for="selectionCount"> Selection Count </label>
 						<input
-							id="seatCount"
-							v-model.number="formData.seatCount"
+							id="selectionCount"
+							v-model.number="formData.selectionCount"
 							type="number"
 							min="1"
 							:disabled="!canEdit"
@@ -894,7 +894,7 @@ watch(
 					</div>
 					<div class="info-row">
 						<span class="info-label">Selection Count:</span>
-						<span class="info-value">{{ motion.seatCount }}</span>
+						<span class="info-value">{{ motion.selectionCount }}</span>
 					</div>
 					<div class="info-row">
 						<span class="info-label">Duration:</span>
@@ -974,7 +974,7 @@ watch(
 					</div>
 					<div class="info-row">
 						<span class="info-label">Selection Count:</span>
-						<span class="info-value">{{ motion.seatCount }}</span>
+						<span class="info-value">{{ motion.selectionCount }}</span>
 					</div>
 					<div class="info-row">
 						<span class="info-label">Duration:</span>
@@ -1046,8 +1046,11 @@ watch(
 						<div class="choice-results">
 							<h4>
 								Vote Distribution
-								<span v-if="detailedResults.seatCount > 1" class="seats-info">
-									(Top {{ detailedResults.seatCount }} win)
+								<span
+									v-if="detailedResults.selectionCount > 1"
+									class="seats-info"
+								>
+									(Top {{ detailedResults.selectionCount }} win)
 								</span>
 							</h4>
 

--- a/packages/client/src/views/admin/MotionList.vue
+++ b/packages/client/src/views/admin/MotionList.vue
@@ -448,7 +448,7 @@ watch(currentPage, () => {
 							{{ motion.description || "—" }}
 						</td>
 						<td>{{ motion.plannedDuration }} min</td>
-						<td>{{ motion.seatCount }}</td>
+						<td>{{ motion.selectionCount }}</td>
 						<td>{{ motion.votingPoolName || "—" }}</td>
 						<td>
 							<span class="status-badge" :class="getStatusClass(motion.status)">

--- a/packages/client/src/views/voter/MotionDetail.vue
+++ b/packages/client/src/views/voter/MotionDetail.vue
@@ -110,7 +110,7 @@ const canSelectMore = computed((): boolean => {
 	if (motion.value === null || isAbstaining.value) {
 		return false;
 	}
-	return selectedChoiceIds.value.length < motion.value.seatCount;
+	return selectedChoiceIds.value.length < motion.value.selectionCount;
 });
 
 // Check if vote is ready to submit
@@ -137,7 +137,7 @@ const isUnderVoting = computed((): boolean => {
 		return false;
 	}
 	const selectedCount = selectedChoiceIds.value.length;
-	const maxAllowed = motion.value.seatCount;
+	const maxAllowed = motion.value.selectionCount;
 	const totalChoices = motion.value.choices.length;
 
 	// Under-voting if: selected < max allowed AND selected < total available choices
@@ -344,7 +344,7 @@ onUnmounted((): void => {
 				</div>
 				<div class="info-item">
 					<span class="info-label">Selections</span>
-					<span class="info-value">{{ motion.seatCount }}</span>
+					<span class="info-value">{{ motion.selectionCount }}</span>
 				</div>
 				<div class="info-item">
 					<span class="info-label">Voting Pool</span>
@@ -364,7 +364,8 @@ onUnmounted((): void => {
 			<div v-else class="voting-section">
 				<h3>Cast Your Vote</h3>
 				<p class="vote-instructions">
-					Select up to {{ motion.seatCount }} choice(s), or choose to abstain.
+					Select up to {{ motion.selectionCount }} choice(s), or choose to
+					abstain.
 				</p>
 
 				<!-- Choices list -->
@@ -414,7 +415,9 @@ onUnmounted((): void => {
 				<!-- Selection summary -->
 				<div v-if="selectedChoiceIds.length > 0" class="selection-summary">
 					<p>
-						Selected ({{ selectedChoiceIds.length }}/{{ motion.seatCount }}):
+						Selected ({{ selectedChoiceIds.length }}/{{
+							motion.selectionCount
+						}}):
 						{{ selectedChoices.map((c) => c.name).join(", ") }}
 					</p>
 				</div>
@@ -456,8 +459,8 @@ onUnmounted((): void => {
 						<p>
 							<strong>Note:</strong> You have selected
 							{{ selectedChoiceIds.length }} choice(s), but you may select up to
-							{{ Math.min(motion.seatCount, motion.choices.length) }}. To change
-							your selections, click Cancel.
+							{{ Math.min(motion.selectionCount, motion.choices.length) }}. To
+							change your selections, click Cancel.
 						</p>
 					</div>
 					<p class="warning-text">

--- a/packages/client/src/views/watcher/WatcherMotionReport.vue
+++ b/packages/client/src/views/watcher/WatcherMotionReport.vue
@@ -189,7 +189,7 @@ onMounted(() => {
 					</div>
 					<div class="detail-item">
 						<span class="detail-label">Selections</span>
-						<span class="detail-value">{{ motion.seatCount }}</span>
+						<span class="detail-value">{{ motion.selectionCount }}</span>
 					</div>
 					<div class="detail-item">
 						<span class="detail-label">Planned Duration</span>

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,6 +25,7 @@
 		"@pdc/http-status-codes": "^1.0.1",
 		"bcrypt": "^6.0.0",
 		"csv-parse": "^6.1.0",
+		"dotenv": "^17.4.1",
 		"express": "^4.21.2",
 		"jsonwebtoken": "^9.0.3",
 		"multer": "^2.0.2",

--- a/packages/server/src/database/migrations/0012-rename-seat-count-to-selection-count.sql
+++ b/packages/server/src/database/migrations/0012-rename-seat-count-to-selection-count.sql
@@ -1,0 +1,12 @@
+-- Migration: Rename seat_count to selection_count
+-- Issue: #32 - Rename seat_count to selection_count in database schema
+-- Description: Rename column and constraint for consistency with UI terminology
+
+-- Rename the column
+ALTER TABLE motions RENAME COLUMN seat_count TO selection_count;
+
+-- Rename the constraint
+ALTER TABLE motions RENAME CONSTRAINT motions_valid_seat_count TO motions_valid_selection_count;
+
+-- Update the column comment
+COMMENT ON COLUMN motions.selection_count IS 'Number of selections/positions to elect (default 1)';

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -1241,7 +1241,7 @@ adminRouter.post(
 				name: body.name,
 				plannedDuration: body.plannedDuration,
 				description: body.description,
-				seatCount: body.seatCount,
+				selectionCount: body.selectionCount,
 				votingPoolId: body.votingPoolId,
 			};
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,6 +1,7 @@
 /**
  * Server entry point
  */
+import "dotenv/config";
 import pino from "pino";
 import { createApp } from "./app.js";
 import { testConnection, initializeDatabase } from "./database/index.js";

--- a/packages/server/src/services/meeting-service.ts
+++ b/packages/server/src/services/meeting-service.ts
@@ -34,7 +34,7 @@ const PAGE_OFFSET_ADJUSTMENT = 1;
 const DECIMAL_RADIX = 10;
 
 // Motion defaults
-const DEFAULT_SEAT_COUNT = 1;
+const DEFAULT_SELECTION_COUNT = 1;
 const INITIAL_SORT_ORDER = 0;
 const SORT_ORDER_INCREMENT = 1;
 
@@ -331,7 +331,7 @@ export async function createMotion(
 		name,
 		description,
 		plannedDuration,
-		seatCount,
+		selectionCount,
 		votingPoolId,
 	} = request;
 
@@ -361,7 +361,7 @@ export async function createMotion(
 		name: string;
 		description: string | null;
 		planned_duration: number;
-		seat_count: number;
+		selection_count: number;
 		voting_pool_id: number | null;
 		status: string;
 		end_override: Date | null;
@@ -370,15 +370,15 @@ export async function createMotion(
 		created_at: Date;
 		updated_at: Date;
 	}>(
-		`INSERT INTO motions (meeting_id, name, description, planned_duration, seat_count, voting_pool_id)
-		 VALUES (:meetingId, :name, :description, :plannedDuration, :seatCount, :votingPoolId)
+		`INSERT INTO motions (meeting_id, name, description, planned_duration, selection_count, voting_pool_id)
+		 VALUES (:meetingId, :name, :description, :plannedDuration, :selectionCount, :votingPoolId)
 		 RETURNING *`,
 		{
 			meetingId,
 			name,
 			description: description ?? null,
 			plannedDuration,
-			seatCount: seatCount ?? DEFAULT_SEAT_COUNT,
+			selectionCount: selectionCount ?? DEFAULT_SELECTION_COUNT,
 			votingPoolId: votingPoolId ?? null,
 		},
 	);
@@ -392,7 +392,7 @@ export async function createMotion(
 		name: row.name,
 		description: row.description,
 		plannedDuration: row.planned_duration,
-		seatCount: row.seat_count,
+		selectionCount: row.selection_count,
 		votingPoolId: row.voting_pool_id,
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Database enum returns as string
 		status: row.status as MotionStatus,
@@ -416,7 +416,7 @@ export async function getMotionById(
 		name: string;
 		description: string | null;
 		planned_duration: number;
-		seat_count: number;
+		selection_count: number;
 		voting_pool_id: number | null;
 		status: string;
 		end_override: Date | null;
@@ -446,7 +446,7 @@ export async function getMotionById(
 		name: row.name,
 		description: row.description,
 		plannedDuration: row.planned_duration,
-		seatCount: row.seat_count,
+		selectionCount: row.selection_count,
 		votingPoolId: row.voting_pool_id,
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Database enum returns as string
 		status: row.status as MotionStatus,
@@ -483,7 +483,7 @@ export async function listMotionsForMeeting(
 		name: string;
 		description: string | null;
 		planned_duration: number;
-		seat_count: number;
+		selection_count: number;
 		voting_pool_id: number | null;
 		status: string;
 		end_override: Date | null;
@@ -508,7 +508,7 @@ export async function listMotionsForMeeting(
 		name: row.name,
 		description: row.description,
 		plannedDuration: row.planned_duration,
-		seatCount: row.seat_count,
+		selectionCount: row.selection_count,
 		votingPoolId: row.voting_pool_id,
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Database enum returns as string
 		status: row.status as MotionStatus,
@@ -530,7 +530,7 @@ export async function updateMotion(
 	motionId: number,
 	updates: UpdateMotionRequest,
 ): Promise<Motion> {
-	const { name, description, plannedDuration, seatCount, votingPoolId } =
+	const { name, description, plannedDuration, selectionCount, votingPoolId } =
 		updates;
 
 	// Build dynamic update query
@@ -552,9 +552,9 @@ export async function updateMotion(
 		values.plannedDuration = plannedDuration;
 	}
 
-	if (seatCount !== undefined) {
-		setClauses.push(`seat_count = :seatCount`);
-		values.seatCount = seatCount;
+	if (selectionCount !== undefined) {
+		setClauses.push(`selection_count = :selectionCount`);
+		values.selectionCount = selectionCount;
 	}
 
 	if (votingPoolId !== undefined) {
@@ -583,7 +583,7 @@ export async function updateMotion(
 		name: string;
 		description: string | null;
 		planned_duration: number;
-		seat_count: number;
+		selection_count: number;
 		voting_pool_id: number | null;
 		status: string;
 		end_override: Date | null;
@@ -612,7 +612,7 @@ export async function updateMotion(
 		name: row.name,
 		description: row.description,
 		plannedDuration: row.planned_duration,
-		seatCount: row.seat_count,
+		selectionCount: row.selection_count,
 		votingPoolId: row.voting_pool_id,
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Database enum returns as string
 		status: row.status as MotionStatus,
@@ -672,7 +672,7 @@ export async function updateMotionStatus(
 		name: string;
 		description: string | null;
 		planned_duration: number;
-		seat_count: number;
+		selection_count: number;
 		voting_pool_id: number | null;
 		status: string;
 		end_override: Date | null;
@@ -713,7 +713,7 @@ export async function updateMotionStatus(
 		name: row.name,
 		description: row.description,
 		plannedDuration: row.planned_duration,
-		seatCount: row.seat_count,
+		selectionCount: row.selection_count,
 		votingPoolId: row.voting_pool_id,
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Database enum returns as string
 		status: row.status as MotionStatus,
@@ -761,7 +761,7 @@ export async function setMotionEndOverride(
 		name: string;
 		description: string | null;
 		planned_duration: number;
-		seat_count: number;
+		selection_count: number;
 		voting_pool_id: number | null;
 		status: string;
 		end_override: Date | null;
@@ -786,7 +786,7 @@ export async function setMotionEndOverride(
 		name: row.name,
 		description: row.description,
 		plannedDuration: row.planned_duration,
-		seatCount: row.seat_count,
+		selectionCount: row.selection_count,
 		votingPoolId: row.voting_pool_id,
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Database enum returns as string
 		status: row.status as MotionStatus,
@@ -1235,8 +1235,8 @@ export async function getMotionDetailedResults(
 					? (voteCount / totalVotesForChoices) * PERCENTAGE_MULTIPLIER
 					: ZERO_VOTES;
 
-			// Winner determination: top seat_count choices by vote count
-			const isWinner = index < motion.seatCount;
+			// Winner determination: top selection_count choices by vote count
+			const isWinner = index < motion.selectionCount;
 
 			return {
 				choiceId: row.choice_id,
@@ -1264,7 +1264,7 @@ export async function getMotionDetailedResults(
 	return {
 		motionId: motion.id,
 		motionName: motion.name,
-		seatCount: motion.seatCount,
+		selectionCount: motion.selectionCount,
 		totalVotesIncludingAbstentions,
 		totalVotesForChoices,
 		abstentionCount,

--- a/packages/server/src/services/motion-service.ts
+++ b/packages/server/src/services/motion-service.ts
@@ -18,7 +18,7 @@ interface OpenMotionRow {
 	name: string;
 	description: string | null;
 	planned_duration: number;
-	seat_count: number;
+	selection_count: number;
 	pool_name: string;
 	meeting_id: number;
 	meeting_name: string;
@@ -46,7 +46,7 @@ export async function getOpenMotionsForUser(
 			m.name,
 			m.description,
 			m.planned_duration,
-			m.seat_count,
+			m.selection_count,
 			COALESCE(p.pool_name, qp.pool_name) as pool_name,
 			mt.id as meeting_id,
 			mt.name as meeting_name,
@@ -84,7 +84,7 @@ export async function getOpenMotionsForUser(
 			name: row.name,
 			description: row.description,
 			plannedDuration: row.planned_duration,
-			seatCount: row.seat_count,
+			selectionCount: row.selection_count,
 			votingPoolName: row.pool_name,
 			meetingId: row.meeting_id,
 			meetingName: row.meeting_name,

--- a/packages/server/src/services/vote-service.ts
+++ b/packages/server/src/services/vote-service.ts
@@ -28,7 +28,7 @@ interface MotionRow {
 	name: string;
 	description: string | null;
 	planned_duration: number;
-	seat_count: number;
+	selection_count: number;
 	pool_name: string;
 	meeting_id: number;
 	meeting_name: string;
@@ -112,7 +112,7 @@ export async function getMotionForVoting(
 			m.name,
 			m.description,
 			m.planned_duration,
-			m.seat_count,
+			m.selection_count,
 			m.status,
 			COALESCE(p.pool_name, qp.pool_name) as pool_name,
 			mt.id as meeting_id,
@@ -195,7 +195,7 @@ export async function getMotionForVoting(
 		name: motionRow.name,
 		description: motionRow.description,
 		plannedDuration: motionRow.planned_duration,
-		seatCount: motionRow.seat_count,
+		selectionCount: motionRow.selection_count,
 		votingPoolName: motionRow.pool_name,
 		meetingId: motionRow.meeting_id,
 		meetingName: motionRow.meeting_name,
@@ -244,9 +244,9 @@ function validateVoteChoices(
 	}
 
 	// Validate choice count against seat count
-	if (!abstain && choiceIds.length > motion.seatCount) {
+	if (!abstain && choiceIds.length > motion.selectionCount) {
 		throw new Error(
-			`You can only select up to ${String(motion.seatCount)} choice(s)`,
+			`You can only select up to ${String(motion.selectionCount)} choice(s)`,
 		);
 	}
 
@@ -268,7 +268,7 @@ function validateVoteChoices(
  * 1. Motion exists and is voting_active
  * 2. User hasn't already voted
  * 3. User is in the voting pool
- * 4. Choice count doesn't exceed seat_count (unless abstaining)
+ * 4. Choice count doesn't exceed selection_count (unless abstaining)
  * 5. All choice IDs belong to this motion
  */
 export async function castVote(

--- a/packages/server/src/services/watcher-service.ts
+++ b/packages/server/src/services/watcher-service.ts
@@ -144,7 +144,7 @@ async function getMotionSummariesForMeeting(
 		id: number;
 		name: string;
 		status: string;
-		seat_count: number;
+		selection_count: number;
 		voting_started_at: Date | null;
 		voting_ended_at: Date | null;
 		voting_pool_name: string | null;
@@ -152,7 +152,7 @@ async function getMotionSummariesForMeeting(
 		total_abstentions: string;
 	}>(
 		`SELECT
-			m.id, m.name, m.status, m.seat_count,
+			m.id, m.name, m.status, m.selection_count,
 			m.voting_started_at, m.voting_ended_at,
 			p.pool_name as voting_pool_name,
 			COALESCE(v.total_votes, 0) as total_votes,
@@ -182,7 +182,7 @@ async function getMotionSummariesForMeeting(
 			// eslint-disable-next-line no-await-in-loop -- Sequential motion processing for results
 			result = await getWatcherMotionResultInternal(
 				motion.id,
-				motion.seat_count,
+				motion.selection_count,
 			);
 		}
 
@@ -278,17 +278,19 @@ export async function getWatcherMotionResult(
 	motionId: number,
 ): Promise<WatcherMotionResult> {
 	// Verify motion exists and is completed
-	const motionResult = await db.query<{ status: string; seat_count: number }>(
-		"SELECT status, seat_count FROM motions WHERE id = :motionId",
-		{ motionId },
-	);
+	const motionResult = await db.query<{
+		status: string;
+		selection_count: number;
+	}>("SELECT status, selection_count FROM motions WHERE id = :motionId", {
+		motionId,
+	});
 
 	if (motionResult.rows.length === EMPTY_ARRAY_LENGTH) {
 		throw new Error(`Motion with ID ${String(motionId)} not found`);
 	}
 
 	const {
-		rows: [{ status, seat_count: seatCount }],
+		rows: [{ status, selection_count: selectionCount }],
 	} = motionResult;
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- Database enum returns as string
 	if (status !== MotionStatus.VotingComplete) {
@@ -297,7 +299,7 @@ export async function getWatcherMotionResult(
 		);
 	}
 
-	return await getWatcherMotionResultInternal(motionId, seatCount);
+	return await getWatcherMotionResultInternal(motionId, selectionCount);
 }
 
 /**
@@ -305,7 +307,7 @@ export async function getWatcherMotionResult(
  */
 async function getWatcherMotionResultInternal(
 	motionId: number,
-	seatCount: number,
+	selectionCount: number,
 ): Promise<WatcherMotionResult> {
 	// Get vote counts per choice
 	const choiceResultsQuery = await db.query<{
@@ -326,18 +328,18 @@ async function getWatcherMotionResultInternal(
 		{ motionId },
 	);
 
-	// Determine winners (top seat_count choices by vote count)
+	// Determine winners (top selection_count choices by vote count)
 	const choiceTallies: WatcherChoiceTally[] = choiceResultsQuery.rows.map(
 		(row, index) => ({
 			choiceId: row.choice_id,
 			choiceName: row.choice_name,
 			voteCount: parseInt(row.vote_count, DECIMAL_RADIX),
-			isWinner: index < seatCount,
+			isWinner: index < selectionCount,
 		}),
 	);
 
 	return {
-		seatCount,
+		selectionCount,
 		choiceTallies,
 	};
 }
@@ -354,7 +356,7 @@ export async function getWatcherMotionDetail(
 		name: string;
 		description: string | null;
 		status: string;
-		seat_count: number;
+		selection_count: number;
 		planned_duration: number;
 		voting_started_at: Date | null;
 		voting_ended_at: Date | null;
@@ -365,7 +367,7 @@ export async function getWatcherMotionDetail(
 		voting_pool_id: number | null;
 	}>(
 		`SELECT
-			m.id, m.name, m.description, m.status, m.seat_count,
+			m.id, m.name, m.description, m.status, m.selection_count,
 			m.planned_duration, m.voting_started_at, m.voting_ended_at,
 			m.end_override, m.meeting_id,
 			mt.name as meeting_name,
@@ -429,7 +431,10 @@ export async function getWatcherMotionDetail(
 	// Get result if motion is completed
 	let result: WatcherMotionResult | null = null;
 	if (status === MotionStatus.VotingComplete) {
-		result = await getWatcherMotionResultInternal(motionId, motion.seat_count);
+		result = await getWatcherMotionResultInternal(
+			motionId,
+			motion.selection_count,
+		);
 	}
 
 	return {
@@ -437,7 +442,7 @@ export async function getWatcherMotionDetail(
 		motionName: motion.name,
 		description: motion.description,
 		status,
-		seatCount: motion.seat_count,
+		selectionCount: motion.selection_count,
 		meetingId: motion.meeting_id,
 		meetingName: motion.meeting_name,
 		votingPoolName: motion.voting_pool_name,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -384,7 +384,7 @@ export interface MeetingWithPool extends Meeting {
  * - name: VARCHAR(255) NOT NULL
  * - description: TEXT (nullable)
  * - planned_duration: INTEGER NOT NULL (minutes)
- * - seat_count: INTEGER NOT NULL DEFAULT 1
+ * - selection_count: INTEGER NOT NULL DEFAULT 1
  * - voting_pool_id: INTEGER REFERENCES pools(id) ON DELETE RESTRICT (nullable)
  * - status: motion_status NOT NULL DEFAULT 'not_yet_started'
  * - end_override: TIMESTAMP WITH TIME ZONE (nullable, only when status='voting_active')
@@ -401,7 +401,7 @@ export interface Motion {
 	name: string;
 	description: string | null;
 	plannedDuration: number;
-	seatCount: number;
+	selectionCount: number;
 	votingPoolId: number | null;
 	status: MotionStatus;
 	endOverride: Date | null;
@@ -470,7 +470,7 @@ export interface CreateMotionRequest {
 	name: string;
 	description?: string;
 	plannedDuration: number;
-	seatCount?: number; // Defaults to 1
+	selectionCount?: number; // Defaults to 1
 	votingPoolId?: number;
 }
 
@@ -481,7 +481,7 @@ export interface UpdateMotionRequest {
 	name?: string;
 	description?: string;
 	plannedDuration?: number;
-	seatCount?: number;
+	selectionCount?: number;
 	votingPoolId?: number;
 }
 
@@ -569,7 +569,7 @@ export interface ChoiceResult {
 	choiceName: string;
 	voteCount: number; // Number of votes for this choice
 	percentage: number; // Percentage of total votes cast (excluding abstentions)
-	isWinner: boolean; // True if this choice won (top seat_count choices)
+	isWinner: boolean; // True if this choice won (top selection_count choices)
 }
 
 /**
@@ -584,7 +584,7 @@ export interface ChoiceResult {
 export interface MotionDetailedResults {
 	motionId: number;
 	motionName: string;
-	seatCount: number; // Number of seats/winners
+	selectionCount: number; // Number of seats/winners
 	totalVotesIncludingAbstentions: number; // Total ballots cast
 	totalVotesForChoices: number; // Votes cast for choices (excluding abstentions)
 	abstentionCount: number; // Number of abstentions
@@ -666,7 +666,7 @@ export enum LoginErrorCode {
  *
  * This type is returned by the voter API, not directly mapped to a database table.
  * It joins data from:
- * - motions table (id, name, description, planned_duration, seat_count, voting_started_at, end_override)
+ * - motions table (id, name, description, planned_duration, selection_count, voting_started_at, end_override)
  * - meetings table (meeting_id, meeting_name)
  * - pools table (voting_pool_name via motion's voting_pool_id or meeting's quorum_voting_pool_id)
  *
@@ -682,7 +682,7 @@ export interface OpenMotionForVoter {
 	name: string;
 	description: string | null;
 	plannedDuration: number;
-	seatCount: number;
+	selectionCount: number;
 	votingPoolName: string;
 	meetingId: number;
 	meetingName: string;
@@ -852,7 +852,7 @@ export interface WatcherChoiceTally {
  * Shows tallies but NOT who voted for what
  */
 export interface WatcherMotionResult {
-	seatCount: number;
+	selectionCount: number;
 	choiceTallies: WatcherChoiceTally[];
 }
 
@@ -924,7 +924,7 @@ export interface WatcherMotionDetail {
 	motionName: string;
 	description: string | null;
 	status: MotionStatus;
-	seatCount: number;
+	selectionCount: number;
 	// Meeting info for navigation
 	meetingId: number;
 	meetingName: string;


### PR DESCRIPTION
## Summary

- Renames database column `seat_count` to `selection_count` for consistency with UI terminology
- Updates all TypeScript types, server services, and client components to use `selectionCount`
- Adds `dotenv` to server for automatic `.env` file loading during development

## Changes

### Database
- New migration `0012-rename-seat-count-to-selection-count.sql` renames the column and constraint

### Server
- Updated shared types (`Motion`, `MotionWithPool`, `WatcherMotionResult`, etc.)
- Updated services: `meeting-service.ts`, `motion-service.ts`, `vote-service.ts`, `watcher-service.ts`
- Updated routes: `admin.ts`
- Added `dotenv/config` import to `server.ts` for automatic `.env` loading

### Client
- Updated components: `MotionCard.vue`
- Updated admin views: `MotionCreate.vue`, `MotionDetail.vue`, `MotionList.vue`
- Updated voter view: `MotionDetail.vue`
- Updated watcher view: `WatcherMotionReport.vue`

## Test plan

- [x] Database migration applies successfully
- [x] Admin can create motions with selection count
- [x] Admin can edit motion selection count
- [x] Motion list displays selection count correctly
- [x] Voter view shows selection count and enforces limit
- [x] Watcher reports display selection count

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)