### PR TITLE
Implement meeting-based user access control (#96)

### DIFF
--- a/packages/client/src/composables/useAdminMeeting.ts
+++ b/packages/client/src/composables/useAdminMeeting.ts
@@ -1,0 +1,111 @@
+/**
+ * Admin meeting composable for managing joined meeting state
+ */
+import { ref, computed } from "vue";
+import {
+	getCurrentMeetingForAdmin,
+	joinMeetingAsAdmin,
+	leaveMeetingAsAdmin,
+} from "../services/api";
+import type { CurrentMeetingInfo } from "@mcdc-convention-voting/shared";
+
+// Module-level state (singleton pattern)
+const currentMeeting = ref<CurrentMeetingInfo | null>(null);
+const isLoading = ref(false);
+const isInitialized = ref(false);
+
+/**
+ * Admin meeting composable for tracking current joined meeting
+ */
+export function useAdminMeeting(): {
+	currentMeeting: typeof currentMeeting;
+	isJoined: ReturnType<typeof computed<boolean>>;
+	joinedMeetingId: ReturnType<typeof computed<number | null>>;
+	joinedMeetingAdminPoolId: ReturnType<typeof computed<number | null>>;
+	isLoading: typeof isLoading;
+	isInitialized: typeof isInitialized;
+	loadCurrentMeeting: () => Promise<void>;
+	joinMeeting: (meetingId: number) => Promise<void>;
+	leaveMeeting: () => Promise<void>;
+} {
+	const isJoined = computed(() => currentMeeting.value !== null);
+	const joinedMeetingId = computed(
+		() => currentMeeting.value?.meeting.id ?? null,
+	);
+	const joinedMeetingAdminPoolId = computed(
+		() => currentMeeting.value?.meeting.adminPoolId ?? null,
+	);
+
+	/**
+	 * Load current meeting state from server
+	 */
+	async function loadCurrentMeeting(): Promise<void> {
+		isLoading.value = true;
+
+		try {
+			const response = await getCurrentMeetingForAdmin();
+
+			if (response.success) {
+				currentMeeting.value = response.data ?? null;
+			} else {
+				currentMeeting.value = null;
+			}
+		} catch {
+			currentMeeting.value = null;
+		} finally {
+			isLoading.value = false;
+			isInitialized.value = true;
+		}
+	}
+
+	/**
+	 * Join a meeting as admin
+	 */
+	async function joinMeeting(meetingId: number): Promise<void> {
+		isLoading.value = true;
+
+		try {
+			const response = await joinMeetingAsAdmin(meetingId);
+
+			if (!response.success) {
+				throw new Error(response.error ?? "Failed to join meeting");
+			}
+
+			// Reload current meeting to get full info
+			await loadCurrentMeeting();
+		} finally {
+			isLoading.value = false;
+		}
+	}
+
+	/**
+	 * Leave the current meeting
+	 */
+	async function leaveMeeting(): Promise<void> {
+		isLoading.value = true;
+
+		try {
+			const response = await leaveMeetingAsAdmin();
+
+			if (!response.success) {
+				throw new Error(response.error ?? "Failed to leave meeting");
+			}
+
+			currentMeeting.value = null;
+		} finally {
+			isLoading.value = false;
+		}
+	}
+
+	return {
+		currentMeeting,
+		isJoined,
+		joinedMeetingId,
+		joinedMeetingAdminPoolId,
+		isLoading,
+		isInitialized,
+		loadCurrentMeeting,
+		joinMeeting,
+		leaveMeeting,
+	};
+}

--- a/packages/client/src/composables/useAuth.ts
+++ b/packages/client/src/composables/useAuth.ts
@@ -26,6 +26,7 @@ export function useAuth(): {
 	isAuthenticated: ReturnType<typeof computed<boolean>>;
 	isAdmin: ReturnType<typeof computed<boolean>>;
 	isWatcher: ReturnType<typeof computed<boolean>>;
+	isMeetingAdmin: ReturnType<typeof computed<boolean>>;
 	isLoading: typeof isLoading;
 	isInitialized: typeof isInitialized;
 	login: (username: string, password: string) => Promise<void>;
@@ -37,6 +38,9 @@ export function useAuth(): {
 	const isAuthenticated = computed(() => currentUser.value !== null);
 	const isAdmin = computed(() => currentUser.value?.isAdmin ?? false);
 	const isWatcher = computed(() => currentUser.value?.isWatcher ?? false);
+	const isMeetingAdmin = computed(
+		() => currentUser.value?.isMeetingAdmin ?? false,
+	);
 
 	/**
 	 * Login with username and password
@@ -113,6 +117,7 @@ export function useAuth(): {
 		isAuthenticated,
 		isAdmin,
 		isWatcher,
+		isMeetingAdmin,
 		isLoading,
 		isInitialized,
 		login,

--- a/packages/client/src/router/index.ts
+++ b/packages/client/src/router/index.ts
@@ -23,16 +23,19 @@ import MeetingList from "../views/admin/MeetingList.vue";
 import MeetingCreate from "../views/admin/MeetingCreate.vue";
 import MeetingEdit from "../views/admin/MeetingEdit.vue";
 import MeetingQuorum from "../views/admin/MeetingQuorum.vue";
+import MeetingAdminSelection from "../views/admin/MeetingAdminSelection.vue";
 import MotionList from "../views/admin/MotionList.vue";
 import MotionCreate from "../views/admin/MotionCreate.vue";
 import AdminMotionDetail from "../views/admin/MotionDetail.vue";
 import VoterDashboard from "../views/voter/VoterDashboard.vue";
 import VoterMotionDetail from "../views/voter/MotionDetail.vue";
 import MyPools from "../views/voter/MyPools.vue";
+import MeetingSelection from "../views/voter/MeetingSelection.vue";
 import WatcherLayout from "../views/WatcherLayout.vue";
 import WatcherDashboard from "../views/watcher/WatcherDashboard.vue";
 import WatcherMeetingList from "../views/watcher/WatcherMeetingList.vue";
 import WatcherMeetingReport from "../views/watcher/WatcherMeetingReport.vue";
+import WatcherMeetingSelection from "../views/watcher/WatcherMeetingSelection.vue";
 import WatcherMotionReport from "../views/watcher/WatcherMotionReport.vue";
 import WatcherQuorumReport from "../views/watcher/WatcherQuorumReport.vue";
 
@@ -63,6 +66,11 @@ export const router = createRouter({
 					path: "",
 					name: "VoterDashboard",
 					component: VoterDashboard,
+				},
+				{
+					path: "meetings",
+					name: "MeetingSelection",
+					component: MeetingSelection,
 				},
 				{
 					path: "motion/:id",
@@ -160,6 +168,11 @@ export const router = createRouter({
 					component: MeetingCreate,
 				},
 				{
+					path: "meetings/select",
+					name: "MeetingAdminSelection",
+					component: MeetingAdminSelection,
+				},
+				{
 					path: "meetings/:id/edit",
 					name: "MeetingEdit",
 					component: MeetingEdit,
@@ -202,6 +215,11 @@ export const router = createRouter({
 					component: WatcherDashboard,
 				},
 				{
+					path: "meeting-selection",
+					name: "WatcherMeetingSelection",
+					component: WatcherMeetingSelection,
+				},
+				{
 					path: "meetings",
 					name: "WatcherMeetingList",
 					component: WatcherMeetingList,
@@ -233,18 +251,19 @@ export const router = createRouter({
 let kioskModeInitialized = false;
 
 /**
- * Check if admin user should be redirected away from a voter-only route
+ * Check if admin or meeting admin user should be redirected away from a voter-only route
  */
 function shouldRedirectAdminFromVoterRoute(
 	path: string,
 	authenticated: boolean,
 	admin: boolean,
+	meetingAdmin: boolean,
 ): boolean {
-	if (!authenticated || !admin) {
+	if (!authenticated || (!admin && !meetingAdmin)) {
 		return false;
 	}
 	// Admin routes are /admin, watcher routes are /watcher, login is /login
-	// Admins should be redirected away from voter routes (/ and its children)
+	// Admins and meeting admins should be redirected away from voter routes (/ and its children)
 	return (
 		!path.startsWith("/admin") &&
 		!path.startsWith("/watcher") &&
@@ -283,9 +302,16 @@ function initializeKioskModeOnce(): void {
 /**
  * Get the appropriate home path for a user based on their role
  */
-function getHomePath(admin: boolean, watcher: boolean): string {
+function getHomePath(
+	admin: boolean,
+	watcher: boolean,
+	meetingAdmin: boolean,
+): string {
 	if (admin) {
 		return "/admin";
+	}
+	if (meetingAdmin) {
+		return "/admin/meetings/select";
 	}
 	if (watcher) {
 		return "/watcher";
@@ -297,6 +323,7 @@ interface AuthState {
 	authenticated: boolean;
 	admin: boolean;
 	watcher: boolean;
+	meetingAdmin: boolean;
 }
 
 interface RouteQuery {
@@ -317,11 +344,11 @@ function checkMetaRequirements(
 	toMeta: RouteMeta,
 	authState: AuthState,
 ): string | null {
-	const { authenticated, admin, watcher } = authState;
+	const { authenticated, admin, watcher, meetingAdmin } = authState;
 
 	// Guest-only routes (like login) - redirect authenticated users
 	if (toMeta.guestOnly === true && authenticated) {
-		return getHomePath(admin, watcher);
+		return getHomePath(admin, watcher, meetingAdmin);
 	}
 
 	// Protected routes - redirect unauthenticated users to login
@@ -329,14 +356,14 @@ function checkMetaRequirements(
 		return "/login";
 	}
 
-	// Admin-only routes - redirect non-admins
-	if (toMeta.requiresAdmin === true && !admin) {
-		return getHomePath(admin, watcher);
+	// Admin-only routes - allow global admins and meeting admins
+	if (toMeta.requiresAdmin === true && !admin && !meetingAdmin) {
+		return getHomePath(admin, watcher, meetingAdmin);
 	}
 
 	// Watcher-only routes - redirect non-watchers
 	if (toMeta.requiresWatcher === true && !watcher) {
-		return getHomePath(admin, watcher);
+		return getHomePath(admin, watcher, meetingAdmin);
 	}
 
 	return null;
@@ -349,16 +376,23 @@ function checkPathBasedRedirects(
 	toPath: string,
 	authState: AuthState,
 ): string | null {
-	const { authenticated, admin, watcher } = authState;
+	const { authenticated, admin, watcher, meetingAdmin } = authState;
 
 	// Redirect watcher users away from non-watcher routes
 	if (shouldRedirectWatcherFromOtherRoute(toPath, authenticated, watcher)) {
 		return "/watcher";
 	}
 
-	// Redirect admin users away from voter-only routes to admin panel
-	if (shouldRedirectAdminFromVoterRoute(toPath, authenticated, admin)) {
-		return "/admin";
+	// Redirect admin/meeting admin users away from voter-only routes
+	if (
+		shouldRedirectAdminFromVoterRoute(
+			toPath,
+			authenticated,
+			admin,
+			meetingAdmin,
+		)
+	) {
+		return getHomePath(admin, watcher, meetingAdmin);
 	}
 
 	return null;
@@ -368,8 +402,14 @@ function checkPathBasedRedirects(
  * Navigation guard for authentication and authorization
  */
 router.beforeEach(async (to) => {
-	const { isAuthenticated, isAdmin, isWatcher, isInitialized, checkAuth } =
-		useAuth();
+	const {
+		isAuthenticated,
+		isAdmin,
+		isWatcher,
+		isMeetingAdmin,
+		isInitialized,
+		checkAuth,
+	} = useAuth();
 	const { getKioskModeQueryParam } = useKioskMode();
 
 	initializeKioskModeOnce();
@@ -386,6 +426,7 @@ router.beforeEach(async (to) => {
 		authenticated: isAuthenticated.value,
 		admin: isAdmin.value,
 		watcher: isWatcher.value,
+		meetingAdmin: isMeetingAdmin.value,
 	};
 
 	// Check route meta requirements first

--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -35,7 +35,9 @@ import type {
 	WatcherMotionDetail,
 	WatcherMotionVoter,
 	WatcherMotionResult,
-	CSVImportResult,
+	JoinableMeeting,
+	CurrentMeetingInfo,
+	MeetingParticipant,
 } from "@mcdc-convention-voting/shared";
 
 // Constants
@@ -871,6 +873,79 @@ export async function getMyPools(): Promise<ApiResponse<Pool[]>> {
 }
 
 /**
+ * Meeting Participation API Functions
+ */
+
+interface JoinableMeetingsData {
+	data: JoinableMeeting[];
+}
+
+interface CurrentMeetingData {
+	data: CurrentMeetingInfo | null;
+}
+
+interface JoinMeetingData {
+	data: {
+		participant: MeetingParticipant;
+		meeting: MeetingWithPool;
+	};
+}
+
+interface LeaveMeetingData {
+	data: {
+		success: boolean;
+	};
+}
+
+/**
+ * Get list of active meetings the user can join as a voter
+ */
+export async function getJoinableMeetings(): Promise<
+	ApiResponse<JoinableMeetingsData>
+> {
+	return await apiRequest<ApiResponse<JoinableMeetingsData>>(
+		`${API_PREFIX}/voter/meetings/joinable`,
+	);
+}
+
+/**
+ * Get the user's current active meeting
+ */
+export async function getCurrentMeeting(): Promise<
+	ApiResponse<CurrentMeetingData>
+> {
+	return await apiRequest<ApiResponse<CurrentMeetingData>>(
+		`${API_PREFIX}/voter/meetings/current`,
+	);
+}
+
+/**
+ * Join a meeting as a voter
+ */
+export async function joinMeeting(
+	meetingId: number,
+): Promise<ApiResponse<JoinMeetingData>> {
+	return await apiRequest<ApiResponse<JoinMeetingData>>(
+		`${API_PREFIX}/voter/meetings/${meetingId}/join`,
+		{
+			method: "POST",
+		},
+	);
+}
+
+/**
+ * Leave the current meeting
+ */
+export async function leaveMeeting(): Promise<ApiResponse<LeaveMeetingData>> {
+	return await apiRequest<ApiResponse<LeaveMeetingData>>(
+		`${API_PREFIX}/voter/meetings/leave`,
+		{
+			method: "POST",
+		},
+	);
+}
+
+/**
  * Quorum Management API Functions
  */
 
@@ -996,6 +1071,115 @@ export async function getWatcherMotionResult(
 ): Promise<ApiResponse<WatcherMotionResult>> {
 	return await apiRequest<ApiResponse<WatcherMotionResult>>(
 		`${API_PREFIX}/watcher/motions/${motionId}/results`,
+	);
+}
+
+/**
+ * Watcher Meeting Participation API Functions
+ */
+
+/**
+ * Get list of active meetings the user can join as a watcher
+ */
+export async function getJoinableMeetingsForWatcher(): Promise<
+	ApiResponse<JoinableMeetingsData>
+> {
+	return await apiRequest<ApiResponse<JoinableMeetingsData>>(
+		`${API_PREFIX}/watcher/meetings/joinable`,
+	);
+}
+
+/**
+ * Get the watcher's current active meeting
+ */
+export async function getCurrentMeetingForWatcher(): Promise<
+	ApiResponse<CurrentMeetingData>
+> {
+	return await apiRequest<ApiResponse<CurrentMeetingData>>(
+		`${API_PREFIX}/watcher/meetings/current`,
+	);
+}
+
+/**
+ * Join a meeting as a watcher
+ */
+export async function joinMeetingAsWatcher(
+	meetingId: number,
+): Promise<ApiResponse<JoinMeetingData>> {
+	return await apiRequest<ApiResponse<JoinMeetingData>>(
+		`${API_PREFIX}/watcher/meetings/${meetingId}/join`,
+		{
+			method: "POST",
+		},
+	);
+}
+
+/**
+ * Leave the current meeting as a watcher
+ */
+export async function leaveMeetingAsWatcher(): Promise<
+	ApiResponse<LeaveMeetingData>
+> {
+	return await apiRequest<ApiResponse<LeaveMeetingData>>(
+		`${API_PREFIX}/watcher/meetings/leave`,
+		{
+			method: "POST",
+		},
+	);
+}
+
+/**
+ * Meeting Admin API Functions
+ * For users who are meeting admins (not global admins)
+ */
+
+/**
+ * Get meetings the current user can administer
+ */
+export async function getJoinableMeetingsForAdmin(): Promise<
+	ApiResponse<{ data: JoinableMeeting[] }>
+> {
+	return await apiRequest<ApiResponse<{ data: JoinableMeeting[] }>>(
+		`${API_PREFIX}/admin/meetings/joinable`,
+	);
+}
+
+/**
+ * Get current meeting for meeting admin
+ */
+export async function getCurrentMeetingForAdmin(): Promise<
+	ApiResponse<CurrentMeetingInfo | null>
+> {
+	return await apiRequest<ApiResponse<CurrentMeetingInfo | null>>(
+		`${API_PREFIX}/admin/meetings/current`,
+	);
+}
+
+/**
+ * Join a meeting as meeting admin
+ */
+export async function joinMeetingAsAdmin(
+	meetingId: number,
+): Promise<ApiResponse<JoinMeetingData>> {
+	return await apiRequest<ApiResponse<JoinMeetingData>>(
+		`${API_PREFIX}/admin/meetings/${meetingId}/join`,
+		{
+			method: "POST",
+		},
+	);
+}
+
+/**
+ * Leave the current meeting as meeting admin
+ */
+export async function leaveMeetingAsAdmin(): Promise<
+	ApiResponse<LeaveMeetingData>
+> {
+	return await apiRequest<ApiResponse<LeaveMeetingData>>(
+		`${API_PREFIX}/admin/meetings/leave`,
+		{
+			method: "POST",
+		},
 	);
 }
 

--- a/packages/client/src/views/AdminLayout.vue
+++ b/packages/client/src/views/AdminLayout.vue
@@ -24,8 +24,9 @@ const adminRoleLabel = computed(() => {
 	return "Admin";
 });
 
-// Show Users and Pools menus for both global admins and meeting admins
-const showAdminMenus = computed(() => isAdmin.value || isMeetingAdmin.value);
+// Users and Pools menus are global-admin only; scoped meeting admins only see
+// the Meetings dropdown for the meeting(s) they can administer.
+const showAdminMenus = computed(() => isAdmin.value);
 
 // Handle leaving the current meeting
 async function handleLeaveMeeting(): Promise<void> {

--- a/packages/client/src/views/AdminLayout.vue
+++ b/packages/client/src/views/AdminLayout.vue
@@ -1,13 +1,47 @@
 <script setup lang="ts">
+import { computed, onMounted } from "vue";
 import { RouterLink } from "vue-router";
 import { useAuth } from "../composables/useAuth";
+import { useAdminMeeting } from "../composables/useAdminMeeting";
 import { useMobileNav } from "../composables/useMobileNav";
 import NavDropdown from "../components/NavDropdown.vue";
 import NavHamburger from "../components/NavHamburger.vue";
 import MobileNavOverlay from "../components/MobileNavOverlay.vue";
 
-const { currentUser, logout } = useAuth();
+const { currentUser, isAdmin, isMeetingAdmin, logout } = useAuth();
+const { isJoined, currentMeeting, loadCurrentMeeting, leaveMeeting } =
+	useAdminMeeting();
 const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
+
+// Determine the admin role label for the header
+const adminRoleLabel = computed(() => {
+	if (isAdmin.value) {
+		return "Admin";
+	}
+	if (isMeetingAdmin.value) {
+		return "Meeting Admin";
+	}
+	return "Admin";
+});
+
+// Show Users and Pools menus for both global admins and meeting admins
+const showAdminMenus = computed(() => isAdmin.value || isMeetingAdmin.value);
+
+// Handle leaving the current meeting
+async function handleLeaveMeeting(): Promise<void> {
+	await leaveMeeting();
+}
+
+// Handle leaving from mobile nav (also close nav)
+async function handleLeaveMeetingMobile(): Promise<void> {
+	await leaveMeeting();
+	closeNav();
+}
+
+// Load current meeting state on mount
+onMounted(() => {
+	void loadCurrentMeeting();
+});
 </script>
 
 <template>
@@ -15,7 +49,7 @@ const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
 		<header class="admin-header">
 			<div class="header-top">
 				<RouterLink to="/admin" class="logo-link">
-					<h1>MCDC Convention Voting - Admin</h1>
+					<h1>MCDC Convention Voting - {{ adminRoleLabel }}</h1>
 				</RouterLink>
 				<div class="header-right desktop-only">
 					<span v-if="currentUser" class="user-name">
@@ -30,7 +64,7 @@ const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
 				/>
 			</div>
 			<nav class="admin-nav desktop-only">
-				<NavDropdown label="Users">
+				<NavDropdown v-if="showAdminMenus" label="Users">
 					<RouterLink to="/admin/users" class="dropdown-link">
 						All Users
 					</RouterLink>
@@ -47,7 +81,7 @@ const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
 						User Cleanup
 					</RouterLink>
 				</NavDropdown>
-				<NavDropdown label="Pools">
+				<NavDropdown v-if="showAdminMenus" label="Pools">
 					<RouterLink to="/admin/pools" class="dropdown-link">
 						All Pools
 					</RouterLink>
@@ -61,9 +95,32 @@ const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
 						Missing Pools
 					</RouterLink>
 				</NavDropdown>
-				<RouterLink to="/admin/meetings" class="nav-link">
-					Meetings
-				</RouterLink>
+				<NavDropdown label="Meetings">
+					<RouterLink to="/admin/meetings" class="dropdown-link">
+						{{ isJoined ? currentMeeting?.meeting.name : "All Meetings" }}
+					</RouterLink>
+					<RouterLink
+						v-if="isAdmin"
+						to="/admin/meetings/create"
+						class="dropdown-link"
+					>
+						Create Meeting
+					</RouterLink>
+					<RouterLink
+						v-if="!isJoined"
+						to="/admin/meetings/select"
+						class="dropdown-link"
+					>
+						Join Meeting
+					</RouterLink>
+					<a
+						v-else
+						class="dropdown-link leave-link"
+						@click="handleLeaveMeeting"
+					>
+						Leave Meeting
+					</a>
+				</NavDropdown>
 			</nav>
 		</header>
 
@@ -75,7 +132,7 @@ const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
 				</div>
 
 				<!-- Users section -->
-				<div class="mobile-nav-section">
+				<div v-if="showAdminMenus" class="mobile-nav-section">
 					<div class="mobile-nav-section-title">Users</div>
 					<RouterLink
 						to="/admin/users"
@@ -115,7 +172,7 @@ const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
 				</div>
 
 				<!-- Pools section -->
-				<div class="mobile-nav-section">
+				<div v-if="showAdminMenus" class="mobile-nav-section">
 					<div class="mobile-nav-section-title">Pools</div>
 					<RouterLink
 						to="/admin/pools"
@@ -155,8 +212,31 @@ const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
 						class="mobile-nav-link"
 						@click="closeNav"
 					>
-						All Meetings
+						{{ isJoined ? currentMeeting?.meeting.name : "All Meetings" }}
 					</RouterLink>
+					<RouterLink
+						v-if="isAdmin"
+						to="/admin/meetings/create"
+						class="mobile-nav-link"
+						@click="closeNav"
+					>
+						Create Meeting
+					</RouterLink>
+					<RouterLink
+						v-if="!isJoined"
+						to="/admin/meetings/select"
+						class="mobile-nav-link"
+						@click="closeNav"
+					>
+						Join Meeting
+					</RouterLink>
+					<a
+						v-else
+						class="mobile-nav-link leave-link"
+						@click="handleLeaveMeetingMobile"
+					>
+						Leave Meeting
+					</a>
 				</div>
 
 				<button class="mobile-logout-btn" @click="logout">Logout</button>
@@ -264,6 +344,15 @@ const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
 	color: #007bff;
 }
 
+.dropdown-link.leave-link {
+	cursor: pointer;
+	color: #c62828;
+}
+
+.dropdown-link.leave-link:hover {
+	background-color: #ffebee;
+}
+
 .admin-content {
 	flex: 1;
 	padding: 2rem;
@@ -316,6 +405,15 @@ const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
 
 .mobile-nav-link:hover {
 	background-color: rgba(255, 255, 255, 0.1);
+}
+
+.mobile-nav-link.leave-link {
+	cursor: pointer;
+	color: #ff8a80;
+}
+
+.mobile-nav-link.leave-link:hover {
+	background-color: rgba(255, 138, 128, 0.2);
 }
 
 .mobile-logout-btn {

--- a/packages/client/src/views/VoterLayout.vue
+++ b/packages/client/src/views/VoterLayout.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, watch } from "vue";
-import { RouterLink, useRouter } from "vue-router";
+import { ref, onMounted, onUnmounted, watch } from "vue";
+import { RouterLink, useRouter, useRoute } from "vue-router";
 import { useAuth } from "../composables/useAuth";
 import { useKioskMode } from "../composables/useKioskMode";
 import { useActivityTimeout } from "../composables/useActivityTimeout";
 import { useMobileNav } from "../composables/useMobileNav";
+import { getCurrentMeeting } from "../services/api";
 import KioskModeIndicator from "../components/KioskModeIndicator.vue";
 import InactivityWarningModal from "../components/InactivityWarningModal.vue";
 import NavHamburger from "../components/NavHamburger.vue";
 import MobileNavOverlay from "../components/MobileNavOverlay.vue";
 
 const router = useRouter();
+const route = useRoute();
 const { currentUser, isAdmin, logout } = useAuth();
 const { isKioskMode, getKioskModeQueryParam } = useKioskMode();
 const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
@@ -21,6 +23,8 @@ const {
 	startTracking,
 	stopTracking,
 } = useActivityTimeout();
+
+const meetingCheckComplete = ref(false);
 
 /**
  * Handle inactivity logout - called when countdown expires
@@ -47,8 +51,39 @@ function updateActivityTracking(): void {
 // Watch for changes in kiosk mode or admin status
 watch([isKioskMode, isAdmin], updateActivityTracking);
 
+/**
+ * Check if user has an active meeting participation
+ * Redirects to meeting selection if not
+ */
+async function checkMeetingParticipation(): Promise<void> {
+	// Skip check if already on meetings page
+	if (route.path === "/meetings") {
+		meetingCheckComplete.value = true;
+		return;
+	}
+
+	try {
+		const response = await getCurrentMeeting();
+		if (response.success && response.data !== undefined) {
+			const currentMeeting = response.data.data;
+			if (currentMeeting === null) {
+				// User has no active meeting, redirect to meeting selection
+				const kioskQuery = getKioskModeQueryParam();
+				void router.push({ path: "/meetings", query: kioskQuery });
+			}
+		}
+	} catch {
+		// On error, redirect to meeting selection
+		const kioskQuery = getKioskModeQueryParam();
+		void router.push({ path: "/meetings", query: kioskQuery });
+	} finally {
+		meetingCheckComplete.value = true;
+	}
+}
+
 onMounted(() => {
 	updateActivityTracking();
+	void checkMeetingParticipation();
 });
 
 onUnmounted(() => {
@@ -57,7 +92,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-	<div class="voter-layout">
+	<div v-if="meetingCheckComplete" class="voter-layout">
 		<header class="header">
 			<div class="header-content">
 				<RouterLink to="/" class="logo-link">

--- a/packages/client/src/views/VoterLayout.vue
+++ b/packages/client/src/views/VoterLayout.vue
@@ -51,6 +51,18 @@ function updateActivityTracking(): void {
 // Watch for changes in kiosk mode or admin status
 watch([isKioskMode, isAdmin], updateActivityTracking);
 
+// Re-check meeting participation on every navigation so a user who is kicked
+// mid-session is redirected to meeting selection on the next route change.
+watch(
+	() => route.path,
+	(newPath, oldPath) => {
+		if (newPath === oldPath) {
+			return;
+		}
+		void checkMeetingParticipation();
+	},
+);
+
 /**
  * Check if user has an active meeting participation
  * Redirects to meeting selection if not

--- a/packages/client/src/views/WatcherLayout.vue
+++ b/packages/client/src/views/WatcherLayout.vue
@@ -1,16 +1,54 @@
 <script setup lang="ts">
-import { RouterLink } from "vue-router";
+import { ref, onMounted } from "vue";
+import { RouterLink, useRouter, useRoute } from "vue-router";
 import { useAuth } from "../composables/useAuth";
 import { useMobileNav } from "../composables/useMobileNav";
+import { getCurrentMeetingForWatcher } from "../services/api";
 import NavHamburger from "../components/NavHamburger.vue";
 import MobileNavOverlay from "../components/MobileNavOverlay.vue";
 
+const router = useRouter();
+const route = useRoute();
 const { currentUser, logout } = useAuth();
 const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
+
+const meetingCheckComplete = ref(false);
+
+/**
+ * Check if watcher has an active meeting participation
+ * Redirects to meeting selection if not
+ */
+async function checkMeetingParticipation(): Promise<void> {
+	// Skip check if already on watcher meeting selection page
+	if (route.path === "/watcher/meeting-selection") {
+		meetingCheckComplete.value = true;
+		return;
+	}
+
+	try {
+		const response = await getCurrentMeetingForWatcher();
+		if (response.success && response.data !== undefined) {
+			const currentMeeting = response.data.data;
+			if (currentMeeting === null) {
+				// Watcher has no active meeting, redirect to meeting selection
+				void router.push("/watcher/meeting-selection");
+			}
+		}
+	} catch {
+		// On error, redirect to meeting selection
+		void router.push("/watcher/meeting-selection");
+	} finally {
+		meetingCheckComplete.value = true;
+	}
+}
+
+onMounted(() => {
+	void checkMeetingParticipation();
+});
 </script>
 
 <template>
-	<div class="watcher-layout">
+	<div v-if="meetingCheckComplete" class="watcher-layout">
 		<header class="watcher-header">
 			<div class="header-top">
 				<RouterLink to="/watcher" class="logo-link">

--- a/packages/client/src/views/WatcherLayout.vue
+++ b/packages/client/src/views/WatcherLayout.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from "vue";
 import { RouterLink, useRouter, useRoute } from "vue-router";
 import { useAuth } from "../composables/useAuth";
+import { useKioskMode } from "../composables/useKioskMode";
 import { useMobileNav } from "../composables/useMobileNav";
 import { getCurrentMeetingForWatcher } from "../services/api";
 import NavHamburger from "../components/NavHamburger.vue";
@@ -10,6 +11,7 @@ import MobileNavOverlay from "../components/MobileNavOverlay.vue";
 const router = useRouter();
 const route = useRoute();
 const { currentUser, logout } = useAuth();
+const { getKioskModeQueryParam } = useKioskMode();
 const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
 
 const meetingCheckComplete = ref(false);
@@ -31,12 +33,20 @@ async function checkMeetingParticipation(): Promise<void> {
 			const currentMeeting = response.data.data;
 			if (currentMeeting === null) {
 				// Watcher has no active meeting, redirect to meeting selection
-				void router.push("/watcher/meeting-selection");
+				const kioskQuery = getKioskModeQueryParam();
+				void router.push({
+					path: "/watcher/meeting-selection",
+					query: kioskQuery,
+				});
 			}
 		}
 	} catch {
 		// On error, redirect to meeting selection
-		void router.push("/watcher/meeting-selection");
+		const kioskQuery = getKioskModeQueryParam();
+		void router.push({
+			path: "/watcher/meeting-selection",
+			query: kioskQuery,
+		});
 	} finally {
 		meetingCheckComplete.value = true;
 	}

--- a/packages/client/src/views/admin/MeetingAdminSelection.vue
+++ b/packages/client/src/views/admin/MeetingAdminSelection.vue
@@ -1,0 +1,282 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import { useAuth } from "../../composables/useAuth";
+import { useAdminMeeting } from "../../composables/useAdminMeeting";
+import { getJoinableMeetingsForAdmin } from "../../services/api";
+import type { JoinableMeeting } from "@mcdc-convention-voting/shared";
+
+const { currentUser } = useAuth();
+const { joinMeeting } = useAdminMeeting();
+const router = useRouter();
+
+const meetings = ref<JoinableMeeting[]>([]);
+const loading = ref(true);
+const error = ref<string | null>(null);
+const joiningMeetingId = ref<number | null>(null);
+
+async function loadJoinableMeetings(): Promise<void> {
+	try {
+		const response = await getJoinableMeetingsForAdmin();
+		if (response.success && response.data !== undefined) {
+			meetings.value = response.data.data;
+		} else {
+			error.value = response.error ?? "Failed to load meetings";
+		}
+	} catch (err) {
+		error.value =
+			err instanceof Error ? err.message : "Failed to load meetings";
+	} finally {
+		loading.value = false;
+	}
+}
+
+async function handleJoinMeeting(meetingId: number): Promise<void> {
+	joiningMeetingId.value = meetingId;
+	error.value = null;
+
+	try {
+		// Use composable's joinMeeting to update singleton state
+		await joinMeeting(meetingId);
+		// Navigate to admin dashboard for the meeting
+		void router.push("/admin");
+	} catch (err) {
+		error.value = err instanceof Error ? err.message : "Failed to join meeting";
+	} finally {
+		joiningMeetingId.value = null;
+	}
+}
+
+function formatDate(date: Date): string {
+	return new Date(date).toLocaleString();
+}
+
+function retryLoad(): void {
+	loading.value = true;
+	error.value = null;
+	void loadJoinableMeetings();
+}
+
+onMounted((): void => {
+	void loadJoinableMeetings();
+});
+</script>
+
+<template>
+	<div class="meeting-selection">
+		<div class="welcome-section">
+			<h2>Welcome, {{ currentUser?.firstName }}!</h2>
+			<p>Please select a meeting to administer.</p>
+		</div>
+
+		<section class="selection-section">
+			<h3>Available Meetings</h3>
+
+			<div v-if="loading" class="loading-state">
+				<p>Loading available meetings...</p>
+			</div>
+
+			<div v-else-if="error !== null" class="error-state">
+				<p>{{ error }}</p>
+				<button class="btn btn-primary" @click="retryLoad">Retry</button>
+			</div>
+
+			<div v-else-if="meetings.length === 0" class="empty-state">
+				<p>No meetings are currently available for you to administer.</p>
+				<p class="hint">
+					Please wait for a meeting to become active, or contact a global
+					administrator if you believe this is an error.
+				</p>
+			</div>
+
+			<div v-else class="meetings-list">
+				<div v-for="meeting in meetings" :key="meeting.id" class="meeting-card">
+					<div class="meeting-info">
+						<h4>{{ meeting.name }}</h4>
+						<p v-if="meeting.description" class="description">
+							{{ meeting.description }}
+						</p>
+						<div class="meeting-meta">
+							<span class="pool-badge admin-badge">Admin Access</span>
+							<span class="date-range">
+								{{ formatDate(meeting.startDate) }} -
+								{{ formatDate(meeting.endDate) }}
+							</span>
+						</div>
+					</div>
+					<button
+						class="btn btn-primary join-btn"
+						:disabled="joiningMeetingId !== null"
+						@click="handleJoinMeeting(meeting.id)"
+					>
+						<span v-if="joiningMeetingId === meeting.id">Joining...</span>
+						<span v-else>Administer Meeting</span>
+					</button>
+				</div>
+			</div>
+		</section>
+	</div>
+</template>
+
+<style scoped>
+.meeting-selection {
+	max-width: 800px;
+}
+
+.welcome-section {
+	margin-bottom: 2rem;
+}
+
+.welcome-section h2 {
+	margin: 0 0 0.5rem 0;
+	color: #2c3e50;
+}
+
+.welcome-section p {
+	margin: 0;
+	color: #666;
+}
+
+.selection-section {
+	background: white;
+	border-radius: 8px;
+	padding: 1.5rem;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.selection-section h3 {
+	margin: 0 0 1rem 0;
+	color: #2c3e50;
+	font-size: 1.25rem;
+	border-bottom: 2px solid #1976d2;
+	padding-bottom: 0.5rem;
+}
+
+.loading-state {
+	text-align: center;
+	padding: 2rem;
+	color: #666;
+}
+
+.error-state {
+	text-align: center;
+	padding: 2rem;
+	color: #dc3545;
+}
+
+.error-state p {
+	margin: 0 0 1rem 0;
+}
+
+.empty-state {
+	text-align: center;
+	padding: 2rem;
+	color: #666;
+}
+
+.empty-state p {
+	margin: 0 0 0.5rem 0;
+}
+
+.empty-state .hint {
+	font-size: 0.875rem;
+	color: #999;
+}
+
+.meetings-list {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.meeting-card {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 1rem;
+	border: 1px solid #e0e0e0;
+	border-radius: 8px;
+	background: #fafafa;
+}
+
+.meeting-info {
+	flex: 1;
+}
+
+.meeting-info h4 {
+	margin: 0 0 0.5rem 0;
+	color: #2c3e50;
+}
+
+.meeting-info .description {
+	margin: 0 0 0.5rem 0;
+	color: #666;
+	font-size: 0.9rem;
+}
+
+.meeting-meta {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	align-items: center;
+	font-size: 0.85rem;
+}
+
+.pool-badge {
+	background: #e3f2fd;
+	color: #1565c0;
+	padding: 0.25rem 0.5rem;
+	border-radius: 4px;
+	font-weight: 500;
+}
+
+.admin-badge {
+	background: #fff3e0;
+	color: #e65100;
+}
+
+.date-range {
+	color: #999;
+}
+
+.btn {
+	padding: 0.5rem 1rem;
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 0.9rem;
+	font-weight: 500;
+	transition: background-color 0.2s;
+}
+
+.btn-primary {
+	background-color: #1976d2;
+	color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+	background-color: #1565c0;
+}
+
+.btn-primary:disabled {
+	background-color: #ccc;
+	cursor: not-allowed;
+}
+
+.join-btn {
+	flex-shrink: 0;
+	margin-left: 1rem;
+}
+
+@media (max-width: 600px) {
+	.meeting-card {
+		flex-direction: column;
+		align-items: stretch;
+	}
+
+	.join-btn {
+		margin-left: 0;
+		margin-top: 1rem;
+	}
+}
+</style>

--- a/packages/client/src/views/admin/MeetingCreate.vue
+++ b/packages/client/src/views/admin/MeetingCreate.vue
@@ -20,6 +20,8 @@ const formData = ref({
 	startDate: EMPTY_STRING,
 	endDate: EMPTY_STRING,
 	quorumVotingPoolId: EMPTY_STRING,
+	watcherPoolId: EMPTY_STRING,
+	adminPoolId: EMPTY_STRING,
 });
 
 const saving = ref(false);
@@ -37,36 +39,48 @@ async function loadPools(): Promise<void> {
 	}
 }
 
+interface FormDataType {
+	name: string;
+	description: string;
+	startDate: string;
+	endDate: string;
+	quorumVotingPoolId: string;
+	watcherPoolId: string;
+	adminPoolId: string;
+}
+
+function validateFormData(data: FormDataType): string | null {
+	if (data.name.trim() === EMPTY_STRING) {
+		return "Name is required.";
+	}
+	if (data.startDate === EMPTY_STRING) {
+		return "Start date is required.";
+	}
+	if (data.endDate === EMPTY_STRING) {
+		return "End date is required.";
+	}
+	if (data.quorumVotingPoolId === EMPTY_STRING) {
+		return "Quorum voting pool is required.";
+	}
+	const startDate = new Date(data.startDate);
+	const endDate = new Date(data.endDate);
+	if (endDate <= startDate) {
+		return "End date must be after start date.";
+	}
+	return null;
+}
+
 async function handleSubmit(): Promise<void> {
 	error.value = null;
 
-	if (formData.value.name.trim() === EMPTY_STRING) {
-		error.value = "Name is required.";
-		return;
-	}
-
-	if (formData.value.startDate === EMPTY_STRING) {
-		error.value = "Start date is required.";
-		return;
-	}
-
-	if (formData.value.endDate === EMPTY_STRING) {
-		error.value = "End date is required.";
-		return;
-	}
-
-	if (formData.value.quorumVotingPoolId === EMPTY_STRING) {
-		error.value = "Quorum voting pool is required.";
+	const validationError = validateFormData(formData.value);
+	if (validationError !== null) {
+		error.value = validationError;
 		return;
 	}
 
 	const startDate = new Date(formData.value.startDate);
 	const endDate = new Date(formData.value.endDate);
-
-	if (endDate <= startDate) {
-		error.value = "End date must be after start date.";
-		return;
-	}
 
 	saving.value = true;
 
@@ -81,6 +95,12 @@ async function handleSubmit(): Promise<void> {
 			),
 			...(formData.value.description.trim() !== EMPTY_STRING && {
 				description: formData.value.description.trim(),
+			}),
+			...(formData.value.watcherPoolId !== EMPTY_STRING && {
+				watcherPoolId: Number.parseInt(formData.value.watcherPoolId, 10),
+			}),
+			...(formData.value.adminPoolId !== EMPTY_STRING && {
+				adminPoolId: Number.parseInt(formData.value.adminPoolId, 10),
 			}),
 		};
 
@@ -170,6 +190,51 @@ onMounted(() => {
 				</select>
 				<p class="field-description">
 					The pool used to determine quorum for this meeting
+				</p>
+			</div>
+
+			<div class="form-group">
+				<label for="watcherPoolId">
+					Watcher Pool
+					<span class="optional">(optional)</span>
+				</label>
+				<select
+					id="watcherPoolId"
+					v-model="formData.watcherPoolId"
+					:disabled="loadingPools"
+				>
+					<option value="">
+						{{ loadingPools ? "Loading pools..." : "No watcher pool" }}
+					</option>
+					<option v-for="pool in pools" :key="pool.id" :value="pool.id">
+						{{ pool.poolName }}
+					</option>
+				</select>
+				<p class="field-description">
+					Optional pool of users who can observe this meeting as watchers
+				</p>
+			</div>
+
+			<div class="form-group">
+				<label for="adminPoolId">
+					Admin Pool
+					<span class="optional">(optional)</span>
+				</label>
+				<select
+					id="adminPoolId"
+					v-model="formData.adminPoolId"
+					:disabled="loadingPools"
+				>
+					<option value="">
+						{{ loadingPools ? "Loading pools..." : "No admin pool" }}
+					</option>
+					<option v-for="pool in pools" :key="pool.id" :value="pool.id">
+						{{ pool.poolName }}
+					</option>
+				</select>
+				<p class="field-description">
+					Optional pool of users who can administer this meeting (global admins
+					always have access)
 				</p>
 			</div>
 

--- a/packages/client/src/views/admin/MeetingEdit.vue
+++ b/packages/client/src/views/admin/MeetingEdit.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted } from "vue";
 import { useRouter } from "vue-router";
 import { getMeeting, updateMeeting, getPools } from "../../services/api";
+import { useAuth } from "../../composables/useAuth";
 import type { Pool } from "@mcdc-convention-voting/shared";
 
 const props = defineProps<{
@@ -9,6 +10,7 @@ const props = defineProps<{
 }>();
 
 const router = useRouter();
+const { isAdmin } = useAuth();
 
 // Constants
 const EMPTY_STRING = "";
@@ -28,6 +30,8 @@ const formData = ref({
 	startDate: EMPTY_STRING,
 	endDate: EMPTY_STRING,
 	quorumVotingPoolId: EMPTY_STRING,
+	watcherPoolId: EMPTY_STRING,
+	adminPoolId: EMPTY_STRING,
 });
 
 const loading = ref(false);
@@ -81,6 +85,14 @@ async function loadMeeting(): Promise<void> {
 				startDate: formatDateForInput(meeting.startDate),
 				endDate: formatDateForInput(meeting.endDate),
 				quorumVotingPoolId: String(meeting.quorumVotingPoolId),
+				watcherPoolId:
+					meeting.watcherPoolId === null
+						? EMPTY_STRING
+						: String(meeting.watcherPoolId),
+				adminPoolId:
+					meeting.adminPoolId === null
+						? EMPTY_STRING
+						: String(meeting.adminPoolId),
 			};
 		}
 	} catch (err) {
@@ -90,36 +102,48 @@ async function loadMeeting(): Promise<void> {
 	}
 }
 
+interface FormDataType {
+	name: string;
+	description: string;
+	startDate: string;
+	endDate: string;
+	quorumVotingPoolId: string;
+	watcherPoolId: string;
+	adminPoolId: string;
+}
+
+function validateFormData(data: FormDataType): string | null {
+	if (data.name.trim() === EMPTY_STRING) {
+		return "Name is required.";
+	}
+	if (data.startDate === EMPTY_STRING) {
+		return "Start date is required.";
+	}
+	if (data.endDate === EMPTY_STRING) {
+		return "End date is required.";
+	}
+	if (data.quorumVotingPoolId === EMPTY_STRING) {
+		return "Quorum voting pool is required.";
+	}
+	const startDate = new Date(data.startDate);
+	const endDate = new Date(data.endDate);
+	if (endDate <= startDate) {
+		return "End date must be after start date.";
+	}
+	return null;
+}
+
 async function handleSubmit(): Promise<void> {
 	error.value = null;
 
-	if (formData.value.name.trim() === EMPTY_STRING) {
-		error.value = "Name is required.";
-		return;
-	}
-
-	if (formData.value.startDate === EMPTY_STRING) {
-		error.value = "Start date is required.";
-		return;
-	}
-
-	if (formData.value.endDate === EMPTY_STRING) {
-		error.value = "End date is required.";
-		return;
-	}
-
-	if (formData.value.quorumVotingPoolId === EMPTY_STRING) {
-		error.value = "Quorum voting pool is required.";
+	const validationError = validateFormData(formData.value);
+	if (validationError !== null) {
+		error.value = validationError;
 		return;
 	}
 
 	const startDate = new Date(formData.value.startDate);
 	const endDate = new Date(formData.value.endDate);
-
-	if (endDate <= startDate) {
-		error.value = "End date must be after start date.";
-		return;
-	}
 
 	saving.value = true;
 
@@ -136,6 +160,14 @@ async function handleSubmit(): Promise<void> {
 			),
 			description:
 				trimmedDescription === EMPTY_STRING ? undefined : trimmedDescription,
+			watcherPoolId:
+				formData.value.watcherPoolId === EMPTY_STRING
+					? null
+					: Number.parseInt(formData.value.watcherPoolId, DECIMAL_RADIX),
+			adminPoolId:
+				formData.value.adminPoolId === EMPTY_STRING
+					? null
+					: Number.parseInt(formData.value.adminPoolId, DECIMAL_RADIX),
 		};
 
 		await updateMeeting(meetingId, meetingData);
@@ -221,6 +253,54 @@ onMounted(() => {
 						{{ pool.poolName }}
 					</option>
 				</select>
+			</div>
+
+			<div class="form-group">
+				<label for="watcherPoolId">
+					Watcher Pool
+					<span class="optional">(optional)</span>
+				</label>
+				<select
+					id="watcherPoolId"
+					v-model="formData.watcherPoolId"
+					:disabled="loadingPools"
+				>
+					<option value="">
+						{{ loadingPools ? "Loading pools..." : "No watcher pool" }}
+					</option>
+					<option v-for="pool in pools" :key="pool.id" :value="pool.id">
+						{{ pool.poolName }}
+					</option>
+				</select>
+				<p class="field-description">
+					Optional pool of users who can observe this meeting as watchers
+				</p>
+			</div>
+
+			<div class="form-group">
+				<label for="adminPoolId">
+					Admin Pool
+					<span class="optional">(optional)</span>
+				</label>
+				<select
+					id="adminPoolId"
+					v-model="formData.adminPoolId"
+					:disabled="loadingPools || !isAdmin"
+				>
+					<option value="">
+						{{ loadingPools ? "Loading pools..." : "No admin pool" }}
+					</option>
+					<option v-for="pool in pools" :key="pool.id" :value="pool.id">
+						{{ pool.poolName }}
+					</option>
+				</select>
+				<p class="field-description">
+					Optional pool of users who can administer this meeting (global admins
+					always have access)
+				</p>
+				<p v-if="!isAdmin" class="field-restriction">
+					Only global administrators can change the Admin Pool.
+				</p>
 			</div>
 
 			<div class="form-actions">
@@ -341,5 +421,18 @@ h2 {
 
 .btn-secondary:hover:not(:disabled) {
 	background-color: #616161;
+}
+
+.field-description {
+	margin: 0.5rem 0 0 0;
+	font-size: 0.875rem;
+	color: #666;
+}
+
+.field-restriction {
+	margin: 0.5rem 0 0 0;
+	font-size: 0.875rem;
+	color: #e65100;
+	font-style: italic;
 }
 </style>

--- a/packages/client/src/views/admin/MeetingList.vue
+++ b/packages/client/src/views/admin/MeetingList.vue
@@ -2,10 +2,14 @@
 import { ref, onMounted, computed } from "vue";
 import { useRouter } from "vue-router";
 import { getMeetings, deleteMeeting } from "../../services/api";
+import { useAuth } from "../../composables/useAuth";
+import { useAdminMeeting } from "../../composables/useAdminMeeting";
 import TablePagination from "../../components/TablePagination.vue";
 import type { MeetingWithPool } from "@mcdc-convention-voting/shared";
 
 const router = useRouter();
+const { isAdmin } = useAuth();
+const { isJoined, joinedMeetingId, currentMeeting } = useAdminMeeting();
 
 const MEETINGS_PER_PAGE = 50;
 const INITIAL_PAGE = 1;
@@ -16,6 +20,14 @@ const loading = ref(false);
 const error = ref<string | null>(null);
 const currentPage = ref(INITIAL_PAGE);
 const totalMeetings = ref(INITIAL_TOTAL);
+
+// Filter meetings to only show joined meeting when in joined mode
+const filteredMeetings = computed(() => {
+	if (!isJoined.value) {
+		return meetings.value;
+	}
+	return meetings.value.filter((m) => m.id === joinedMeetingId.value);
+});
 
 const totalPages = computed(() =>
 	Math.ceil(totalMeetings.value / MEETINGS_PER_PAGE),
@@ -99,12 +111,18 @@ onMounted(() => {
 <template>
 	<div class="meeting-list">
 		<div class="header">
-			<h2>Meetings</h2>
-			<div class="actions">
+			<h2>{{ isJoined ? currentMeeting?.meeting.name : "Meetings" }}</h2>
+			<div v-if="isAdmin" class="actions">
 				<router-link to="/admin/meetings/create" class="btn btn-primary">
 					Create Meeting
 				</router-link>
 			</div>
+		</div>
+
+		<!-- Joined meeting indicator -->
+		<div v-if="isJoined" class="joined-indicator">
+			Currently viewing joined meeting. Use the menu to leave and see all
+			meetings.
 		</div>
 
 		<div v-if="error" class="error">
@@ -113,7 +131,7 @@ onMounted(() => {
 
 		<div v-if="loading" class="loading">Loading meetings...</div>
 
-		<div v-else-if="meetings.length === 0" class="empty">
+		<div v-else-if="filteredMeetings.length === 0" class="empty">
 			No meetings found. Create a meeting to get started.
 		</div>
 
@@ -130,7 +148,7 @@ onMounted(() => {
 					</tr>
 				</thead>
 				<tbody>
-					<tr v-for="meeting in meetings" :key="meeting.id">
+					<tr v-for="meeting in filteredMeetings" :key="meeting.id">
 						<td class="meeting-name">
 							{{ meeting.name }}
 						</td>
@@ -212,6 +230,16 @@ onMounted(() => {
 .actions {
 	display: flex;
 	gap: 1rem;
+}
+
+.joined-indicator {
+	background-color: #e3f2fd;
+	color: #1565c0;
+	padding: 0.75rem 1rem;
+	border-radius: 4px;
+	margin-bottom: 1rem;
+	font-size: 0.875rem;
+	border: 1px solid #90caf9;
 }
 
 .error {

--- a/packages/client/src/views/admin/PoolUsers.vue
+++ b/packages/client/src/views/admin/PoolUsers.vue
@@ -2,6 +2,8 @@
 import { ref, onMounted, computed } from "vue";
 import { useRouter } from "vue-router";
 import { getPool, getPoolUsers, removeUserFromPool } from "../../services/api";
+import { useAuth } from "../../composables/useAuth";
+import { useAdminMeeting } from "../../composables/useAdminMeeting";
 import TablePagination from "../../components/TablePagination.vue";
 import type { Pool, User } from "@mcdc-convention-voting/shared";
 
@@ -10,6 +12,28 @@ const props = defineProps<{
 }>();
 
 const router = useRouter();
+const { currentUser } = useAuth();
+const { isJoined, joinedMeetingAdminPoolId } = useAdminMeeting();
+
+// Check if user can be removed from this pool
+// Cannot remove self from joined meeting's admin pool
+function canRemoveUser(userId: string): boolean {
+	// Can always remove other users
+	if (userId !== currentUser.value?.id) {
+		return true;
+	}
+	// Can remove self if not in joined mode
+	if (!isJoined.value) {
+		return true;
+	}
+	// Get the current pool ID
+	const poolId = Number.parseInt(props.id, 10);
+	if (Number.isNaN(poolId)) {
+		return true;
+	}
+	// Cannot remove self from joined meeting's admin pool
+	return poolId !== joinedMeetingAdminPoolId.value;
+}
 
 const USERS_PER_PAGE = 50;
 const INITIAL_PAGE = 1;
@@ -178,11 +202,15 @@ onMounted(() => {
 						</td>
 						<td class="actions-cell">
 							<button
+								v-if="canRemoveUser(user.id)"
 								class="btn btn-small btn-warning"
 								@click="requestRemove(user.id, user.username)"
 							>
 								Remove from Pool
 							</button>
+							<span v-else class="self-protection-note">
+								Cannot remove (joined meeting admin pool)
+							</span>
 						</td>
 					</tr>
 				</tbody>
@@ -340,6 +368,12 @@ onMounted(() => {
 	gap: 0.5rem;
 	flex-wrap: wrap;
 	align-items: center;
+}
+
+.self-protection-note {
+	font-size: 0.8125rem;
+	color: #e65100;
+	font-style: italic;
 }
 
 .btn {

--- a/packages/client/src/views/admin/UserList.vue
+++ b/packages/client/src/views/admin/UserList.vue
@@ -333,7 +333,7 @@ onMounted(() => {
 								Edit
 							</button>
 							<button
-								v-if="!user.isDisabled"
+								v-if="!user.isDisabled && user.id !== currentUser?.id"
 								class="btn btn-small btn-warning"
 								@click="requestDisable(user.id)"
 							>

--- a/packages/client/src/views/voter/MeetingSelection.vue
+++ b/packages/client/src/views/voter/MeetingSelection.vue
@@ -1,0 +1,278 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import { useAuth } from "../../composables/useAuth";
+import { getJoinableMeetings, joinMeeting } from "../../services/api";
+import type { JoinableMeeting } from "@mcdc-convention-voting/shared";
+
+const { currentUser } = useAuth();
+const router = useRouter();
+
+const meetings = ref<JoinableMeeting[]>([]);
+const loading = ref(true);
+const error = ref<string | null>(null);
+const joiningMeetingId = ref<number | null>(null);
+
+async function loadJoinableMeetings(): Promise<void> {
+	try {
+		const response = await getJoinableMeetings();
+		if (response.success && response.data !== undefined) {
+			meetings.value = response.data.data;
+		} else {
+			error.value = response.error ?? "Failed to load meetings";
+		}
+	} catch (err) {
+		error.value =
+			err instanceof Error ? err.message : "Failed to load meetings";
+	} finally {
+		loading.value = false;
+	}
+}
+
+async function handleJoinMeeting(meetingId: number): Promise<void> {
+	joiningMeetingId.value = meetingId;
+	error.value = null;
+
+	try {
+		const response = await joinMeeting(meetingId);
+		if (response.success) {
+			// Navigate to voter dashboard
+			void router.push("/");
+		} else {
+			error.value = response.error ?? "Failed to join meeting";
+		}
+	} catch (err) {
+		error.value = err instanceof Error ? err.message : "Failed to join meeting";
+	} finally {
+		joiningMeetingId.value = null;
+	}
+}
+
+function formatDate(date: Date): string {
+	return new Date(date).toLocaleString();
+}
+
+function retryLoad(): void {
+	loading.value = true;
+	error.value = null;
+	void loadJoinableMeetings();
+}
+
+onMounted((): void => {
+	void loadJoinableMeetings();
+});
+</script>
+
+<template>
+	<div class="meeting-selection">
+		<div class="welcome-section">
+			<h2>Welcome, {{ currentUser?.firstName }}!</h2>
+			<p>Please select a meeting to join.</p>
+		</div>
+
+		<section class="selection-section">
+			<h3>Available Meetings</h3>
+
+			<div v-if="loading" class="loading-state">
+				<p>Loading available meetings...</p>
+			</div>
+
+			<div v-else-if="error !== null" class="error-state">
+				<p>{{ error }}</p>
+				<button class="btn btn-primary" @click="retryLoad">Retry</button>
+			</div>
+
+			<div v-else-if="meetings.length === 0" class="empty-state">
+				<p>No meetings are currently available for you to join.</p>
+				<p class="hint">
+					Please wait for a meeting to become active, or contact an
+					administrator if you believe this is an error.
+				</p>
+			</div>
+
+			<div v-else class="meetings-list">
+				<div v-for="meeting in meetings" :key="meeting.id" class="meeting-card">
+					<div class="meeting-info">
+						<h4>{{ meeting.name }}</h4>
+						<p v-if="meeting.description" class="description">
+							{{ meeting.description }}
+						</p>
+						<div class="meeting-meta">
+							<span class="pool-badge">{{ meeting.quorumVotingPoolName }}</span>
+							<span class="date-range">
+								{{ formatDate(meeting.startDate) }} -
+								{{ formatDate(meeting.endDate) }}
+							</span>
+						</div>
+					</div>
+					<button
+						class="btn btn-primary join-btn"
+						:disabled="joiningMeetingId !== null"
+						@click="handleJoinMeeting(meeting.id)"
+					>
+						<span v-if="joiningMeetingId === meeting.id">Joining...</span>
+						<span v-else>Join Meeting</span>
+					</button>
+				</div>
+			</div>
+		</section>
+	</div>
+</template>
+
+<style scoped>
+.meeting-selection {
+	max-width: 800px;
+}
+
+.welcome-section {
+	margin-bottom: 2rem;
+}
+
+.welcome-section h2 {
+	margin: 0 0 0.5rem 0;
+	color: #2c3e50;
+}
+
+.welcome-section p {
+	margin: 0;
+	color: #666;
+}
+
+.selection-section {
+	background: white;
+	border-radius: 8px;
+	padding: 1.5rem;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.selection-section h3 {
+	margin: 0 0 1rem 0;
+	color: #2c3e50;
+	font-size: 1.25rem;
+	border-bottom: 2px solid #007bff;
+	padding-bottom: 0.5rem;
+}
+
+.loading-state {
+	text-align: center;
+	padding: 2rem;
+	color: #666;
+}
+
+.error-state {
+	text-align: center;
+	padding: 2rem;
+	color: #dc3545;
+}
+
+.error-state p {
+	margin: 0 0 1rem 0;
+}
+
+.empty-state {
+	text-align: center;
+	padding: 2rem;
+	color: #666;
+}
+
+.empty-state p {
+	margin: 0 0 0.5rem 0;
+}
+
+.empty-state .hint {
+	font-size: 0.875rem;
+	color: #999;
+}
+
+.meetings-list {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.meeting-card {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 1rem;
+	border: 1px solid #e0e0e0;
+	border-radius: 8px;
+	background: #fafafa;
+}
+
+.meeting-info {
+	flex: 1;
+}
+
+.meeting-info h4 {
+	margin: 0 0 0.5rem 0;
+	color: #2c3e50;
+}
+
+.meeting-info .description {
+	margin: 0 0 0.5rem 0;
+	color: #666;
+	font-size: 0.9rem;
+}
+
+.meeting-meta {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	align-items: center;
+	font-size: 0.85rem;
+}
+
+.pool-badge {
+	background: #e3f2fd;
+	color: #1565c0;
+	padding: 0.25rem 0.5rem;
+	border-radius: 4px;
+	font-weight: 500;
+}
+
+.date-range {
+	color: #999;
+}
+
+.btn {
+	padding: 0.5rem 1rem;
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 0.9rem;
+	font-weight: 500;
+	transition: background-color 0.2s;
+}
+
+.btn-primary {
+	background-color: #007bff;
+	color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+	background-color: #0056b3;
+}
+
+.btn-primary:disabled {
+	background-color: #ccc;
+	cursor: not-allowed;
+}
+
+.join-btn {
+	flex-shrink: 0;
+	margin-left: 1rem;
+}
+
+@media (max-width: 600px) {
+	.meeting-card {
+		flex-direction: column;
+		align-items: stretch;
+	}
+
+	.join-btn {
+		margin-left: 0;
+		margin-top: 1rem;
+	}
+}
+</style>

--- a/packages/client/src/views/voter/VoterDashboard.vue
+++ b/packages/client/src/views/voter/VoterDashboard.vue
@@ -1,10 +1,17 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from "vue";
+import { ref, onMounted, onUnmounted, computed } from "vue";
 import { useRouter } from "vue-router";
 import { useAuth } from "../../composables/useAuth";
-import { getOpenMotions } from "../../services/api";
+import {
+	getOpenMotions,
+	getCurrentMeeting,
+	leaveMeeting,
+} from "../../services/api";
 import MotionCard from "../../components/MotionCard.vue";
-import type { OpenMotionForVoter } from "@mcdc-convention-voting/shared";
+import type {
+	OpenMotionForVoter,
+	CurrentMeetingInfo,
+} from "@mcdc-convention-voting/shared";
 
 const { currentUser } = useAuth();
 const router = useRouter();
@@ -13,9 +20,26 @@ const router = useRouter();
 const POLL_INTERVAL_MS = 30000;
 
 const motions = ref<OpenMotionForVoter[]>([]);
+const currentMeetingInfo = ref<CurrentMeetingInfo | null>(null);
 const loading = ref(true);
 const error = ref<string | null>(null);
+const leavingMeeting = ref(false);
 let pollIntervalId: ReturnType<typeof setInterval> | null = null;
+
+const currentMeetingName = computed(
+	(): string => currentMeetingInfo.value?.meeting.name ?? "Unknown Meeting",
+);
+
+async function loadCurrentMeeting(): Promise<void> {
+	try {
+		const response = await getCurrentMeeting();
+		if (response.success && response.data !== undefined) {
+			currentMeetingInfo.value = response.data.data;
+		}
+	} catch {
+		// Silently fail - will redirect via VoterLayout if no meeting
+	}
+}
 
 async function loadOpenMotions(): Promise<void> {
 	try {
@@ -32,6 +56,24 @@ async function loadOpenMotions(): Promise<void> {
 	}
 }
 
+async function handleLeaveMeeting(): Promise<void> {
+	leavingMeeting.value = true;
+	try {
+		const response = await leaveMeeting();
+		if (response.success) {
+			// Navigate to meeting selection
+			void router.push("/meetings");
+		} else {
+			error.value = response.error ?? "Failed to leave meeting";
+		}
+	} catch (err) {
+		error.value =
+			err instanceof Error ? err.message : "Failed to leave meeting";
+	} finally {
+		leavingMeeting.value = false;
+	}
+}
+
 function navigateToMotion(motionId: number): void {
 	void router.push(`/motion/${String(motionId)}`);
 }
@@ -43,6 +85,7 @@ function retryLoad(): void {
 }
 
 onMounted((): void => {
+	void loadCurrentMeeting();
 	void loadOpenMotions();
 	// Set up polling for updates
 	pollIntervalId = setInterval((): void => {
@@ -65,6 +108,23 @@ onUnmounted((): void => {
 				You can view and participate in active meetings from this dashboard.
 			</p>
 		</div>
+
+		<!-- Current Meeting Info -->
+		<section v-if="currentMeetingInfo !== null" class="meeting-section">
+			<div class="meeting-header">
+				<div class="meeting-info">
+					<span class="meeting-label">Current Meeting:</span>
+					<span class="meeting-name">{{ currentMeetingName }}</span>
+				</div>
+				<button
+					class="btn btn-secondary"
+					:disabled="leavingMeeting"
+					@click="handleLeaveMeeting"
+				>
+					{{ leavingMeeting ? "Leaving..." : "Leave Meeting" }}
+				</button>
+			</div>
+		</section>
 
 		<section class="dashboard-section">
 			<h3>Active Motions</h3>
@@ -164,6 +224,53 @@ onUnmounted((): void => {
 
 .btn-primary:hover {
 	background-color: #0056b3;
+}
+
+.btn-secondary {
+	background-color: #6c757d;
+	color: white;
+}
+
+.btn-secondary:hover:not(:disabled) {
+	background-color: #545b62;
+}
+
+.btn-secondary:disabled {
+	background-color: #ccc;
+	cursor: not-allowed;
+}
+
+.meeting-section {
+	background: #e3f2fd;
+	border-radius: 8px;
+	padding: 1rem;
+	margin-bottom: 1.5rem;
+	border-left: 4px solid #1565c0;
+}
+
+.meeting-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 1rem;
+}
+
+.meeting-info {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.meeting-label {
+	color: #666;
+	font-size: 0.9rem;
+}
+
+.meeting-name {
+	color: #1565c0;
+	font-weight: 600;
+	font-size: 1.1rem;
 }
 
 .empty-state {

--- a/packages/client/src/views/watcher/WatcherMeetingSelection.vue
+++ b/packages/client/src/views/watcher/WatcherMeetingSelection.vue
@@ -1,0 +1,286 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import { useAuth } from "../../composables/useAuth";
+import {
+	getJoinableMeetingsForWatcher,
+	joinMeetingAsWatcher,
+} from "../../services/api";
+import type { JoinableMeeting } from "@mcdc-convention-voting/shared";
+
+const { currentUser } = useAuth();
+const router = useRouter();
+
+const meetings = ref<JoinableMeeting[]>([]);
+const loading = ref(true);
+const error = ref<string | null>(null);
+const joiningMeetingId = ref<number | null>(null);
+
+async function loadJoinableMeetings(): Promise<void> {
+	try {
+		const response = await getJoinableMeetingsForWatcher();
+		if (response.success && response.data !== undefined) {
+			meetings.value = response.data.data;
+		} else {
+			error.value = response.error ?? "Failed to load meetings";
+		}
+	} catch (err) {
+		error.value =
+			err instanceof Error ? err.message : "Failed to load meetings";
+	} finally {
+		loading.value = false;
+	}
+}
+
+async function handleJoinMeeting(meetingId: number): Promise<void> {
+	joiningMeetingId.value = meetingId;
+	error.value = null;
+
+	try {
+		const response = await joinMeetingAsWatcher(meetingId);
+		if (response.success) {
+			// Navigate to watcher dashboard
+			void router.push("/watcher");
+		} else {
+			error.value = response.error ?? "Failed to join meeting";
+		}
+	} catch (err) {
+		error.value = err instanceof Error ? err.message : "Failed to join meeting";
+	} finally {
+		joiningMeetingId.value = null;
+	}
+}
+
+function formatDate(date: Date): string {
+	return new Date(date).toLocaleString();
+}
+
+function retryLoad(): void {
+	loading.value = true;
+	error.value = null;
+	void loadJoinableMeetings();
+}
+
+onMounted((): void => {
+	void loadJoinableMeetings();
+});
+</script>
+
+<template>
+	<div class="meeting-selection">
+		<div class="welcome-section">
+			<h2>Welcome, {{ currentUser?.firstName }}!</h2>
+			<p>Please select a meeting to observe.</p>
+		</div>
+
+		<section class="selection-section">
+			<h3>Available Meetings</h3>
+
+			<div v-if="loading" class="loading-state">
+				<p>Loading available meetings...</p>
+			</div>
+
+			<div v-else-if="error !== null" class="error-state">
+				<p>{{ error }}</p>
+				<button class="btn btn-primary" @click="retryLoad">Retry</button>
+			</div>
+
+			<div v-else-if="meetings.length === 0" class="empty-state">
+				<p>No meetings are currently available for you to observe.</p>
+				<p class="hint">
+					Please wait for a meeting to become active, or contact an
+					administrator if you believe this is an error.
+				</p>
+			</div>
+
+			<div v-else class="meetings-list">
+				<div v-for="meeting in meetings" :key="meeting.id" class="meeting-card">
+					<div class="meeting-info">
+						<h4>{{ meeting.name }}</h4>
+						<p v-if="meeting.description" class="description">
+							{{ meeting.description }}
+						</p>
+						<div class="meeting-meta">
+							<span class="pool-badge watcher-badge">Observer Access</span>
+							<span class="date-range">
+								{{ formatDate(meeting.startDate) }} -
+								{{ formatDate(meeting.endDate) }}
+							</span>
+						</div>
+					</div>
+					<button
+						class="btn btn-primary join-btn"
+						:disabled="joiningMeetingId !== null"
+						@click="handleJoinMeeting(meeting.id)"
+					>
+						<span v-if="joiningMeetingId === meeting.id">Joining...</span>
+						<span v-else>Observe Meeting</span>
+					</button>
+				</div>
+			</div>
+		</section>
+	</div>
+</template>
+
+<style scoped>
+.meeting-selection {
+	max-width: 800px;
+}
+
+.welcome-section {
+	margin-bottom: 2rem;
+}
+
+.welcome-section h2 {
+	margin: 0 0 0.5rem 0;
+	color: #2c3e50;
+}
+
+.welcome-section p {
+	margin: 0;
+	color: #666;
+}
+
+.selection-section {
+	background: white;
+	border-radius: 8px;
+	padding: 1.5rem;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.selection-section h3 {
+	margin: 0 0 1rem 0;
+	color: #2c3e50;
+	font-size: 1.25rem;
+	border-bottom: 2px solid #6c757d;
+	padding-bottom: 0.5rem;
+}
+
+.loading-state {
+	text-align: center;
+	padding: 2rem;
+	color: #666;
+}
+
+.error-state {
+	text-align: center;
+	padding: 2rem;
+	color: #dc3545;
+}
+
+.error-state p {
+	margin: 0 0 1rem 0;
+}
+
+.empty-state {
+	text-align: center;
+	padding: 2rem;
+	color: #666;
+}
+
+.empty-state p {
+	margin: 0 0 0.5rem 0;
+}
+
+.empty-state .hint {
+	font-size: 0.875rem;
+	color: #999;
+}
+
+.meetings-list {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.meeting-card {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 1rem;
+	border: 1px solid #e0e0e0;
+	border-radius: 8px;
+	background: #fafafa;
+}
+
+.meeting-info {
+	flex: 1;
+}
+
+.meeting-info h4 {
+	margin: 0 0 0.5rem 0;
+	color: #2c3e50;
+}
+
+.meeting-info .description {
+	margin: 0 0 0.5rem 0;
+	color: #666;
+	font-size: 0.9rem;
+}
+
+.meeting-meta {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	align-items: center;
+	font-size: 0.85rem;
+}
+
+.pool-badge {
+	background: #e3f2fd;
+	color: #1565c0;
+	padding: 0.25rem 0.5rem;
+	border-radius: 4px;
+	font-weight: 500;
+}
+
+.watcher-badge {
+	background: #f3e5f5;
+	color: #7b1fa2;
+}
+
+.date-range {
+	color: #999;
+}
+
+.btn {
+	padding: 0.5rem 1rem;
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 0.9rem;
+	font-weight: 500;
+	transition: background-color 0.2s;
+}
+
+.btn-primary {
+	background-color: #6c757d;
+	color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+	background-color: #5a6268;
+}
+
+.btn-primary:disabled {
+	background-color: #ccc;
+	cursor: not-allowed;
+}
+
+.join-btn {
+	flex-shrink: 0;
+	margin-left: 1rem;
+}
+
+@media (max-width: 600px) {
+	.meeting-card {
+		flex-direction: column;
+		align-items: stretch;
+	}
+
+	.join-btn {
+		margin-left: 0;
+		margin-top: 1rem;
+	}
+}
+</style>

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -10,11 +10,8 @@ import { adminRouter } from "./routes/admin.js";
 import { authRouter } from "./routes/auth.js";
 import { voterRouter } from "./routes/voter.js";
 import { watcherRouter } from "./routes/watcher.js";
-import {
-	requireAuth,
-	requireAdmin,
-	requireWatcher,
-} from "./middleware/auth-middleware.js";
+import { requireAuth, requireWatcher } from "./middleware/auth-middleware.js";
+import { requireAdminOrMeetingAdmin } from "./middleware/meeting-admin-middleware.js";
 import { activityLogger } from "./middleware/activity-logger-middleware.js";
 import { getShallowHealth, getDeepHealth } from "./services/health-service.js";
 
@@ -87,7 +84,7 @@ export function createApp(): Express {
 	app.use(
 		`${API_PREFIX}/admin`,
 		requireAuth,
-		requireAdmin,
+		requireAdminOrMeetingAdmin,
 		activityLogger,
 		adminRouter,
 	);

--- a/packages/server/src/database/migrations/0013-add-meeting-participants.sql
+++ b/packages/server/src/database/migrations/0013-add-meeting-participants.sql
@@ -1,0 +1,43 @@
+-- Create participant_role enum type
+CREATE TYPE participant_role AS ENUM ('voter', 'watcher', 'meeting_admin');
+
+COMMENT ON TYPE participant_role IS 'Role of a participant in a meeting: voter, watcher, or meeting_admin';
+
+-- Create meeting_participants table
+-- Tracks which users have joined which meetings and in what capacity
+CREATE TABLE meeting_participants (
+  id SERIAL PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  meeting_id INTEGER NOT NULL REFERENCES meetings(id) ON DELETE CASCADE,
+  role participant_role NOT NULL,
+  joined_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  left_at TIMESTAMP WITH TIME ZONE,
+  quorum_counted_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Index for finding a user's active participation (left_at IS NULL)
+CREATE INDEX idx_meeting_participants_user_active ON meeting_participants(user_id) WHERE left_at IS NULL;
+
+-- Index for finding participants in a meeting
+CREATE INDEX idx_meeting_participants_meeting ON meeting_participants(meeting_id);
+
+-- Index for finding all participations by user
+CREATE INDEX idx_meeting_participants_user ON meeting_participants(user_id);
+
+-- Index for quorum counting (voters who have been counted)
+CREATE INDEX idx_meeting_participants_quorum ON meeting_participants(meeting_id)
+  WHERE role = 'voter' AND quorum_counted_at IS NOT NULL;
+
+-- Add comments for meeting_participants
+COMMENT ON TABLE meeting_participants IS 'Tracks user participation in meetings';
+COMMENT ON COLUMN meeting_participants.id IS 'Unique participation record identifier';
+COMMENT ON COLUMN meeting_participants.user_id IS 'Reference to the participating user';
+COMMENT ON COLUMN meeting_participants.meeting_id IS 'Reference to the meeting being participated in';
+COMMENT ON COLUMN meeting_participants.role IS 'Role of the participant: voter, watcher, or meeting_admin';
+COMMENT ON COLUMN meeting_participants.joined_at IS 'Timestamp when user joined the meeting';
+COMMENT ON COLUMN meeting_participants.left_at IS 'Timestamp when user left the meeting (NULL if still active)';
+COMMENT ON COLUMN meeting_participants.quorum_counted_at IS 'Timestamp when user was counted for quorum (NULL if not counted, only applies to voters)';
+COMMENT ON COLUMN meeting_participants.created_at IS 'Timestamp when record was created';
+COMMENT ON COLUMN meeting_participants.updated_at IS 'Timestamp when record was last updated';

--- a/packages/server/src/database/migrations/0014-add-watcher-pool-to-meetings.sql
+++ b/packages/server/src/database/migrations/0014-add-watcher-pool-to-meetings.sql
@@ -1,0 +1,9 @@
+-- Add watcher pool to meetings
+-- Allows specifying which pool of users can observe this meeting as watchers
+
+ALTER TABLE meetings ADD COLUMN watcher_pool_id INTEGER REFERENCES pools(id) ON DELETE RESTRICT;
+
+COMMENT ON COLUMN meetings.watcher_pool_id IS 'Pool of users who can observe this meeting as watchers (nullable)';
+
+-- Create index for faster lookups
+CREATE INDEX idx_meetings_watcher_pool ON meetings(watcher_pool_id) WHERE watcher_pool_id IS NOT NULL;

--- a/packages/server/src/database/migrations/0015-add-admin-pool-to-meetings.sql
+++ b/packages/server/src/database/migrations/0015-add-admin-pool-to-meetings.sql
@@ -1,0 +1,10 @@
+-- Migration: Add admin_pool_id to meetings table
+-- This allows meetings to have a designated pool of users who can administer the meeting
+-- Global admins always have access; this pool is for meeting-scoped administrators
+
+ALTER TABLE meetings ADD COLUMN admin_pool_id INTEGER REFERENCES pools(id) ON DELETE RESTRICT;
+
+COMMENT ON COLUMN meetings.admin_pool_id IS 'Pool of users who can administer this meeting (nullable, global admins always have access)';
+
+-- Index for efficient lookups when checking admin access
+CREATE INDEX idx_meetings_admin_pool ON meetings(admin_pool_id) WHERE admin_pool_id IS NOT NULL;

--- a/packages/server/src/middleware/auth-middleware.ts
+++ b/packages/server/src/middleware/auth-middleware.ts
@@ -143,8 +143,9 @@ export function requireVoter(
 		return;
 	}
 
-	// Watchers and admins cannot vote
-	if (req.user.isWatcher || req.user.isAdmin) {
+	// Watchers, admins, and meeting admins cannot vote
+	// Only regular voters (users who are in a quorum voting pool) can vote
+	if (req.user.isWatcher || req.user.isAdmin || req.user.isMeetingAdmin) {
 		res.status(HTTP_STATUS.CLIENT_ERROR.FORBIDDEN).json({
 			success: false,
 			error: "Voting privileges required",

--- a/packages/server/src/middleware/auth-middleware.ts
+++ b/packages/server/src/middleware/auth-middleware.ts
@@ -143,9 +143,11 @@ export function requireVoter(
 		return;
 	}
 
-	// Watchers, admins, and meeting admins cannot vote
-	// Only regular voters (users who are in a quorum voting pool) can vote
-	if (req.user.isWatcher || req.user.isAdmin || req.user.isMeetingAdmin) {
+	// Watchers and admins cannot vote.
+	// isMeetingAdmin is NOT checked here: being an admin for some meeting does
+	// not preclude voting in a different meeting where the user is in the
+	// quorum pool.
+	if (req.user.isWatcher || req.user.isAdmin) {
 		res.status(HTTP_STATUS.CLIENT_ERROR.FORBIDDEN).json({
 			success: false,
 			error: "Voting privileges required",

--- a/packages/server/src/middleware/meeting-admin-middleware.ts
+++ b/packages/server/src/middleware/meeting-admin-middleware.ts
@@ -1,0 +1,125 @@
+/**
+ * Meeting Admin middleware for Express routes
+ * Verifies user is either a global admin or a meeting admin for the requested meeting
+ */
+import { HTTP_STATUS } from "@pdc/http-status-codes";
+import { isUserMeetingAdmin } from "../services/meeting-participant-service.js";
+import type { Request, Response, NextFunction } from "express";
+
+// Radix for parsing integers
+const DECIMAL_RADIX = 10;
+
+/**
+ * Create middleware to require meeting admin or global admin privileges
+ * Meeting ID is extracted from request params using the specified parameter name
+ *
+ * @param meetingIdParam - Name of the parameter containing the meeting ID (default: 'meetingId')
+ */
+export function requireMeetingAdmin(
+	meetingIdParam = "meetingId",
+): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+	return async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	): Promise<void> => {
+		if (req.user === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+				success: false,
+				error: "Authentication required",
+			});
+			return;
+		}
+
+		// Global admins always have access
+		if (req.user.isAdmin) {
+			next();
+			return;
+		}
+
+		// Extract meeting ID from params using dynamic key access
+
+		const meetingIdString: string | undefined = req.params[meetingIdParam];
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Runtime guard for missing param
+		if (meetingIdString === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+				success: false,
+				error: `Meeting ID parameter '${meetingIdParam}' not found`,
+			});
+			return;
+		}
+
+		const meetingId = parseInt(meetingIdString, DECIMAL_RADIX);
+		if (Number.isNaN(meetingId)) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+				success: false,
+				error: "Invalid meeting ID",
+			});
+			return;
+		}
+
+		// Check if user is a meeting admin for this specific meeting
+		const isMeetingAdmin = await isUserMeetingAdmin(req.user.id, meetingId);
+		if (!isMeetingAdmin) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.FORBIDDEN).json({
+				success: false,
+				error: "Meeting admin privileges required for this meeting",
+			});
+			return;
+		}
+
+		next();
+	};
+}
+
+/**
+ * Create middleware to require meeting admin or global admin privileges
+ * Meeting ID is extracted from request params using 'id' parameter
+ * Useful for routes like /meetings/:id/...
+ */
+export function requireMeetingAdminById(): (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+) => Promise<void> {
+	return requireMeetingAdmin("id");
+}
+
+/**
+ * Middleware to require either global admin or meeting admin privileges
+ * Does not require a specific meeting ID - allows access if user is admin or is a meeting admin for any meeting
+ * Must be used after requireAuth middleware
+ *
+ * This is useful for endpoints that list all meetings a user can administer
+ */
+export function requireAdminOrMeetingAdmin(
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): void {
+	if (req.user === undefined) {
+		res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+			success: false,
+			error: "Authentication required",
+		});
+		return;
+	}
+
+	// Global admins always have access
+	if (req.user.isAdmin) {
+		next();
+		return;
+	}
+
+	// Meeting admins have access to the admin section
+	if (req.user.isMeetingAdmin) {
+		next();
+		return;
+	}
+
+	// Neither global admin nor meeting admin - deny access
+	res.status(HTTP_STATUS.CLIENT_ERROR.FORBIDDEN).json({
+		success: false,
+		error: "Admin or meeting admin privileges required",
+	});
+}

--- a/packages/server/src/middleware/meeting-admin-middleware.ts
+++ b/packages/server/src/middleware/meeting-admin-middleware.ts
@@ -3,11 +3,78 @@
  * Verifies user is either a global admin or a meeting admin for the requested meeting
  */
 import { HTTP_STATUS } from "@pdc/http-status-codes";
+import {
+	getMeetingIdForChoice,
+	getMeetingIdForMotion,
+} from "../services/meeting-service.js";
 import { isUserMeetingAdmin } from "../services/meeting-participant-service.js";
 import type { Request, Response, NextFunction } from "express";
 
 // Radix for parsing integers
 const DECIMAL_RADIX = 10;
+
+/**
+ * Shared authorization check: global admin passes, otherwise verify the user is
+ * a meeting admin for the specific meeting.
+ */
+async function authorizeForMeeting(
+	req: Request,
+	res: Response,
+	meetingId: number,
+): Promise<boolean> {
+	if (req.user === undefined) {
+		res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+			success: false,
+			error: "Authentication required",
+		});
+		return false;
+	}
+
+	if (req.user.isAdmin) {
+		return true;
+	}
+
+	const isMeetingAdmin = await isUserMeetingAdmin(req.user.id, meetingId);
+	if (!isMeetingAdmin) {
+		res.status(HTTP_STATUS.CLIENT_ERROR.FORBIDDEN).json({
+			success: false,
+			error: "Meeting admin privileges required for this meeting",
+		});
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Parse an integer route param, responding with 400 on failure.
+ * Returns null when the response has already been sent.
+ */
+function parseRouteIdParam(
+	req: Request,
+	res: Response,
+	paramName: string,
+	entityLabel: string,
+): number | null {
+	const raw: string | undefined = req.params[paramName];
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Runtime guard for missing param
+	if (raw === undefined) {
+		res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+			success: false,
+			error: `${entityLabel} ID parameter '${paramName}' not found`,
+		});
+		return null;
+	}
+	const parsed = parseInt(raw, DECIMAL_RADIX);
+	if (Number.isNaN(parsed)) {
+		res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+			success: false,
+			error: `Invalid ${entityLabel.toLowerCase()} ID`,
+		});
+		return null;
+	}
+	return parsed;
+}
 
 /**
  * Create middleware to require meeting admin or global admin privileges
@@ -23,66 +90,93 @@ export function requireMeetingAdmin(
 		res: Response,
 		next: NextFunction,
 	): Promise<void> => {
-		if (req.user === undefined) {
-			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
-				success: false,
-				error: "Authentication required",
-			});
+		const meetingId = parseRouteIdParam(req, res, meetingIdParam, "Meeting");
+		if (meetingId === null) {
 			return;
 		}
 
-		// Global admins always have access
-		if (req.user.isAdmin) {
+		const authorized = await authorizeForMeeting(req, res, meetingId);
+		if (authorized) {
 			next();
-			return;
 		}
-
-		// Extract meeting ID from params using dynamic key access
-
-		const meetingIdString: string | undefined = req.params[meetingIdParam];
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Runtime guard for missing param
-		if (meetingIdString === undefined) {
-			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
-				success: false,
-				error: `Meeting ID parameter '${meetingIdParam}' not found`,
-			});
-			return;
-		}
-
-		const meetingId = parseInt(meetingIdString, DECIMAL_RADIX);
-		if (Number.isNaN(meetingId)) {
-			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
-				success: false,
-				error: "Invalid meeting ID",
-			});
-			return;
-		}
-
-		// Check if user is a meeting admin for this specific meeting
-		const isMeetingAdmin = await isUserMeetingAdmin(req.user.id, meetingId);
-		if (!isMeetingAdmin) {
-			res.status(HTTP_STATUS.CLIENT_ERROR.FORBIDDEN).json({
-				success: false,
-				error: "Meeting admin privileges required for this meeting",
-			});
-			return;
-		}
-
-		next();
 	};
 }
 
 /**
- * Create middleware to require meeting admin or global admin privileges
- * Meeting ID is extracted from request params using 'id' parameter
- * Useful for routes like /meetings/:id/...
+ * Create middleware that authorizes global admins or meeting admins for the
+ * meeting that owns the motion identified by the given route param.
  */
-export function requireMeetingAdminById(): (
-	req: Request,
-	res: Response,
-	next: NextFunction,
-) => Promise<void> {
-	return requireMeetingAdmin("id");
+export function requireMeetingAdminForMotion(
+	motionIdParam = "id",
+): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+	return async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	): Promise<void> => {
+		const motionId = parseRouteIdParam(req, res, motionIdParam, "Motion");
+		if (motionId === null) {
+			return;
+		}
+
+		// Global admins short-circuit without needing the lookup.
+		if (req.user?.isAdmin === true) {
+			next();
+			return;
+		}
+
+		const meetingId = await getMeetingIdForMotion(motionId);
+		if (meetingId === null) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.NOT_FOUND).json({
+				success: false,
+				error: "Motion not found",
+			});
+			return;
+		}
+
+		const authorized = await authorizeForMeeting(req, res, meetingId);
+		if (authorized) {
+			next();
+		}
+	};
+}
+
+/**
+ * Create middleware that authorizes global admins or meeting admins for the
+ * meeting that owns the choice identified by the given route param.
+ */
+export function requireMeetingAdminForChoice(
+	choiceIdParam = "id",
+): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+	return async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	): Promise<void> => {
+		const choiceId = parseRouteIdParam(req, res, choiceIdParam, "Choice");
+		if (choiceId === null) {
+			return;
+		}
+
+		if (req.user?.isAdmin === true) {
+			next();
+			return;
+		}
+
+		const meetingId = await getMeetingIdForChoice(choiceId);
+		if (meetingId === null) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.NOT_FOUND).json({
+				success: false,
+				error: "Choice not found",
+			});
+			return;
+		}
+
+		const authorized = await authorizeForMeeting(req, res, meetingId);
+		if (authorized) {
+			next();
+		}
+	};
 }
 
 /**

--- a/packages/server/src/middleware/watcher-meeting-middleware.ts
+++ b/packages/server/src/middleware/watcher-meeting-middleware.ts
@@ -1,0 +1,129 @@
+/**
+ * Watcher meeting-scoped authorization middleware
+ *
+ * Verifies the authenticated user is authorized to watch a specific meeting
+ * (or the meeting that owns a specific motion). Global admins bypass the
+ * watcher-pool check. Must be used after requireAuth and requireWatcher.
+ */
+import { HTTP_STATUS } from "@pdc/http-status-codes";
+import { getMeetingIdForMotion } from "../services/meeting-service.js";
+import { isUserAuthorizedForMeetingAsWatcher } from "../services/watcher-service.js";
+import type { Request, Response, NextFunction } from "express";
+
+const DECIMAL_RADIX = 10;
+
+function parseRouteIdParam(
+	req: Request,
+	res: Response,
+	paramName: string,
+	entityLabel: string,
+): number | null {
+	const raw: string | undefined = req.params[paramName];
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Runtime guard for missing param
+	if (raw === undefined) {
+		res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+			success: false,
+			error: `${entityLabel} ID parameter '${paramName}' not found`,
+		});
+		return null;
+	}
+	const parsed = parseInt(raw, DECIMAL_RADIX);
+	if (Number.isNaN(parsed)) {
+		res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+			success: false,
+			error: `Invalid ${entityLabel.toLowerCase()} ID`,
+		});
+		return null;
+	}
+	return parsed;
+}
+
+async function authorizeWatcherForMeeting(
+	req: Request,
+	res: Response,
+	meetingId: number,
+): Promise<boolean> {
+	if (req.user === undefined) {
+		res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+			success: false,
+			error: "Authentication required",
+		});
+		return false;
+	}
+
+	if (req.user.isAdmin) {
+		return true;
+	}
+
+	const authorized = await isUserAuthorizedForMeetingAsWatcher(
+		req.user.id,
+		meetingId,
+	);
+	if (!authorized) {
+		res.status(HTTP_STATUS.CLIENT_ERROR.FORBIDDEN).json({
+			success: false,
+			error: "Not authorized to watch this meeting",
+		});
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Require the current user to be a watcher for the meeting identified by the
+ * given route param. Global admins bypass the watcher-pool check.
+ */
+export function requireWatcherForMeeting(
+	meetingIdParam = "id",
+): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+	return async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	): Promise<void> => {
+		const meetingId = parseRouteIdParam(req, res, meetingIdParam, "Meeting");
+		if (meetingId === null) {
+			return;
+		}
+		if (await authorizeWatcherForMeeting(req, res, meetingId)) {
+			next();
+		}
+	};
+}
+
+/**
+ * Require the current user to be a watcher for the meeting that owns the
+ * motion identified by the given route param.
+ */
+export function requireWatcherForMotion(
+	motionIdParam = "id",
+): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+	return async (
+		req: Request,
+		res: Response,
+		next: NextFunction,
+	): Promise<void> => {
+		const motionId = parseRouteIdParam(req, res, motionIdParam, "Motion");
+		if (motionId === null) {
+			return;
+		}
+
+		if (req.user?.isAdmin === true) {
+			next();
+			return;
+		}
+
+		const meetingId = await getMeetingIdForMotion(motionId);
+		if (meetingId === null) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.NOT_FOUND).json({
+				success: false,
+				error: "Motion not found",
+			});
+			return;
+		}
+		if (await authorizeWatcherForMeeting(req, res, meetingId)) {
+			next();
+		}
+	};
+}

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -5,6 +5,32 @@ import { Router, type Request, type Response } from "express";
 import multer from "multer";
 import { HTTP_STATUS } from "@pdc/http-status-codes";
 import {
+	ParticipantRole,
+	type CreateUserRequest,
+	type UpdateUserRequest,
+	type UserListResponse,
+	type BulkPasswordResponse,
+	type PasswordResetResponse,
+	type GeneratePasswordsRequest,
+	type CreatePoolRequest,
+	type UpdatePoolRequest,
+	type PoolListResponse,
+	type PendingPoolKeyListResponse,
+	type ResolvePendingPoolCreateRequest,
+	type ResolvePendingPoolRemapRequest,
+	type CreateMeetingRequest,
+	type UpdateMeetingRequest,
+	type MeetingListResponse,
+	type CreateMotionRequest,
+	type UpdateMotionRequest,
+	type UpdateMotionStatusRequest,
+	type MotionListResponse,
+	type CreateChoiceRequest,
+	type UpdateChoiceRequest,
+	type ReorderChoicesRequest,
+	type ChoiceListResponse,
+} from "@mcdc-convention-voting/shared";
+import {
 	createUser,
 	getUserById,
 	listUsers,
@@ -35,6 +61,7 @@ import {
 	createMeeting,
 	getMeetingById,
 	listMeetings,
+	listMeetingsForMeetingAdmin,
 	updateMeeting,
 	deleteMeeting,
 	createMotion,
@@ -68,31 +95,13 @@ import {
 	resolvePendingByRemapping,
 	deletePendingPoolKey,
 } from "../services/pending-pool-service.js";
-import type {
-	CreateUserRequest,
-	UpdateUserRequest,
-	UserListResponse,
-	BulkPasswordResponse,
-	PasswordResetResponse,
-	GeneratePasswordsRequest,
-	CreatePoolRequest,
-	UpdatePoolRequest,
-	PoolListResponse,
-	PendingPoolKeyListResponse,
-	ResolvePendingPoolCreateRequest,
-	ResolvePendingPoolRemapRequest,
-	CreateMeetingRequest,
-	UpdateMeetingRequest,
-	MeetingListResponse,
-	CreateMotionRequest,
-	UpdateMotionRequest,
-	UpdateMotionStatusRequest,
-	MotionListResponse,
-	CreateChoiceRequest,
-	UpdateChoiceRequest,
-	ReorderChoicesRequest,
-	ChoiceListResponse,
-} from "@mcdc-convention-voting/shared";
+import {
+	getJoinableMeetingsForAdmin,
+	getAllActiveMeetings,
+	joinMeetingAsAdmin,
+	leaveCurrentMeeting,
+	getCurrentMeetingInfo,
+} from "../services/meeting-participant-service.js";
 
 export const adminRouter = Router();
 
@@ -389,6 +398,15 @@ adminRouter.put("/users/:id", async (req: Request, res: Response) => {
  */
 adminRouter.post("/users/:id/disable", async (req: Request, res: Response) => {
 	try {
+		// Prevent users from disabling themselves
+		if (req.params.id === req.user?.id) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+				success: false,
+				error: "Cannot disable your own account",
+			});
+			return;
+		}
+
 		const user = await disableUser(req.params.id);
 		res.json({ success: true, data: user });
 	} catch (error) {
@@ -1025,6 +1043,23 @@ adminRouter.delete(
 			} = req;
 			const poolId = parseInt(id, 10);
 
+			// Check if user is removing themselves from their joined meeting's admin pool
+			if (userId === req.user?.id) {
+				const currentMeeting = await getCurrentMeetingInfo(userId);
+				if (
+					currentMeeting !== null &&
+					currentMeeting.participant.role === ParticipantRole.MeetingAdmin &&
+					currentMeeting.meeting.adminPoolId === poolId
+				) {
+					res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+						success: false,
+						error:
+							"Cannot remove yourself from the admin pool of your current meeting",
+					});
+					return;
+				}
+			}
+
 			await removeUserFromPool(poolId, userId);
 			res.json({
 				success: true,
@@ -1094,6 +1129,8 @@ adminRouter.post("/meetings", async (req: Request, res: Response) => {
 			startDate: request.startDate,
 			endDate: request.endDate,
 			quorumVotingPoolId: request.quorumVotingPoolId,
+			watcherPoolId: request.watcherPoolId,
+			adminPoolId: request.adminPoolId,
 			description: request.description,
 		};
 
@@ -1111,10 +1148,20 @@ adminRouter.post("/meetings", async (req: Request, res: Response) => {
 
 /**
  * GET /api/admin/meetings
- * List all meetings with pagination
+ * List meetings with pagination
+ * For global admins: returns all meetings
+ * For meeting admins: returns only meetings where user is in admin pool
  */
 adminRouter.get("/meetings", async (req: Request, res: Response) => {
 	try {
+		if (req.user === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+				success: false,
+				error: "Authentication required",
+			});
+			return;
+		}
+
 		const pageParam =
 			typeof req.query.page === "string"
 				? req.query.page
@@ -1126,7 +1173,10 @@ adminRouter.get("/meetings", async (req: Request, res: Response) => {
 		const page = Number.parseInt(pageParam, DECIMAL_RADIX);
 		const limit = Number.parseInt(limitParam, DECIMAL_RADIX);
 
-		const { meetings, total } = await listMeetings(page, limit);
+		// Global admins see all meetings; meeting admins only see their authorized meetings
+		const { meetings, total } = req.user.isAdmin
+			? await listMeetings(page, limit)
+			: await listMeetingsForMeetingAdmin(req.user.id, page, limit);
 
 		const response: MeetingListResponse = {
 			data: meetings,
@@ -1144,6 +1194,99 @@ adminRouter.get("/meetings", async (req: Request, res: Response) => {
 		res
 			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
 			.json({ error: `Failed to list meetings: ${message}` });
+	}
+});
+
+// ============================================================================
+// Meeting Admin Selection Routes
+// These routes allow non-global admins who are meeting admins to select and
+// manage the meetings they are authorized to administer
+// IMPORTANT: These routes must be defined before /meetings/:id routes
+// ============================================================================
+
+/**
+ * GET /api/admin/meetings/joinable
+ * Get list of meetings the current user can administer
+ * For global admins, this returns all active meetings
+ * For meeting admins, this returns meetings where they are in the admin pool
+ */
+adminRouter.get("/meetings/joinable", async (req: Request, res: Response) => {
+	try {
+		if (req.user === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+				success: false,
+				error: "Authentication required",
+			});
+			return;
+		}
+
+		// Global admins can join any active meeting
+		// Meeting admins can only join meetings where they are in the admin pool
+		const meetings = req.user.isAdmin
+			? await getAllActiveMeetings()
+			: await getJoinableMeetingsForAdmin(req.user.id);
+		res.json({ success: true, data: { data: meetings } });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		res
+			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+			.json({ success: false, error: `Failed to get meetings: ${message}` });
+	}
+});
+
+/**
+ * GET /api/admin/meetings/current
+ * Get current meeting for meeting admin
+ */
+adminRouter.get("/meetings/current", async (req: Request, res: Response) => {
+	try {
+		if (req.user === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+				success: false,
+				error: "Authentication required",
+			});
+			return;
+		}
+
+		const meetingInfo = await getCurrentMeetingInfo(req.user.id);
+		res.json({ success: true, data: meetingInfo });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		res.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR).json({
+			success: false,
+			error: `Failed to get current meeting: ${message}`,
+		});
+	}
+});
+
+/**
+ * POST /api/admin/meetings/leave
+ * Leave current meeting as meeting admin
+ */
+adminRouter.post("/meetings/leave", async (req: Request, res: Response) => {
+	try {
+		if (req.user === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+				success: false,
+				error: "Authentication required",
+			});
+			return;
+		}
+
+		const success = await leaveCurrentMeeting(req.user.id);
+		if (success) {
+			res.json({ success: true, data: { left: true } });
+		} else {
+			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+				success: false,
+				error: "Not currently in a meeting",
+			});
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		res
+			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+			.json({ success: false, error: `Failed to leave meeting: ${message}` });
 	}
 });
 
@@ -1205,6 +1348,43 @@ adminRouter.delete("/meetings/:id", async (req: Request, res: Response) => {
 		res
 			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
 			.json({ error: `Failed to delete meeting: ${message}` });
+	}
+});
+
+/**
+ * POST /api/admin/meetings/:id/join
+ * Join a meeting as meeting admin
+ */
+adminRouter.post("/meetings/:id/join", async (req: Request, res: Response) => {
+	try {
+		if (req.user === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+				success: false,
+				error: "Authentication required",
+			});
+			return;
+		}
+
+		const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
+		if (Number.isNaN(meetingId)) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+				success: false,
+				error: "Invalid meeting ID",
+			});
+			return;
+		}
+
+		const result = await joinMeetingAsAdmin(
+			req.user.id,
+			meetingId,
+			req.user.isAdmin,
+		);
+		res.json({ success: true, data: result });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		res
+			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+			.json({ success: false, error: `Failed to join meeting: ${message}` });
 	}
 });
 

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -102,6 +102,12 @@ import {
 	leaveCurrentMeeting,
 	getCurrentMeetingInfo,
 } from "../services/meeting-participant-service.js";
+import { requireAdmin } from "../middleware/auth-middleware.js";
+import {
+	requireMeetingAdmin,
+	requireMeetingAdminForChoice,
+	requireMeetingAdminForMotion,
+} from "../middleware/meeting-admin-middleware.js";
 
 export const adminRouter = Router();
 
@@ -190,6 +196,7 @@ const upload = multer({
  */
 adminRouter.post(
 	"/users/upload",
+	requireAdmin,
 	upload.single("file"),
 	async (req: Request, res: Response) => {
 		try {
@@ -220,7 +227,7 @@ adminRouter.post(
  * GET /api/admin/users
  * List all users with pagination and optional search/pool filter
  */
-adminRouter.get("/users", async (req: Request, res: Response) => {
+adminRouter.get("/users", requireAdmin, async (req: Request, res: Response) => {
 	try {
 		const pageParam =
 			typeof req.query.page === "string"
@@ -270,43 +277,47 @@ adminRouter.get("/users", async (req: Request, res: Response) => {
  * POST /api/admin/users
  * Create a single user
  */
-adminRouter.post("/users", async (req: Request, res: Response) => {
-	try {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
-		const request: CreateUserRequest = req.body;
+adminRouter.post(
+	"/users",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
+			const request: CreateUserRequest = req.body;
 
-		// Validate required fields
-		if (
-			isEmptyString(request.voterId) ||
-			isEmptyString(request.firstName) ||
-			isEmptyString(request.lastName)
-		) {
-			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
-				error: "Missing required fields: voterId, firstName, lastName",
-			});
-			return;
+			// Validate required fields
+			if (
+				isEmptyString(request.voterId) ||
+				isEmptyString(request.firstName) ||
+				isEmptyString(request.lastName)
+			) {
+				res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+					error: "Missing required fields: voterId, firstName, lastName",
+				});
+				return;
+			}
+
+			// Trim whitespace from validated fields
+			const trimmedRequest: CreateUserRequest = {
+				...request,
+				voterId: request.voterId.trim(),
+				firstName: request.firstName.trim(),
+				lastName: request.lastName.trim(),
+				username: request.username?.trim(),
+			};
+
+			const user = await createUser(trimmedRequest);
+			res
+				.status(HTTP_STATUS.SUCCESSFUL.CREATED)
+				.json({ success: true, data: user });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to create user: ${message}` });
 		}
-
-		// Trim whitespace from validated fields
-		const trimmedRequest: CreateUserRequest = {
-			...request,
-			voterId: request.voterId.trim(),
-			firstName: request.firstName.trim(),
-			lastName: request.lastName.trim(),
-			username: request.username?.trim(),
-		};
-
-		const user = await createUser(trimmedRequest);
-		res
-			.status(HTTP_STATUS.SUCCESSFUL.CREATED)
-			.json({ success: true, data: user });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to create user: ${message}` });
-	}
-});
+	},
+);
 
 /**
  * GET /api/admin/users/by-date-range
@@ -314,175 +325,203 @@ adminRouter.post("/users", async (req: Request, res: Response) => {
  * Query params: startDate, endDate (ISO format), page, limit
  * NOTE: This route MUST come before /users/:id to avoid being caught by the :id param
  */
-adminRouter.get("/users/by-date-range", async (req: Request, res: Response) => {
-	try {
-		const dateParams = parseDateRangeParams(req.query);
-		if (!dateParams.success) {
+adminRouter.get(
+	"/users/by-date-range",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			const dateParams = parseDateRangeParams(req.query);
+			if (!dateParams.success) {
+				res
+					.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+					.json({ error: dateParams.error });
+				return;
+			}
+
+			const pageParam =
+				typeof req.query.page === "string"
+					? req.query.page
+					: String(DEFAULT_PAGE);
+			const limitParam =
+				typeof req.query.limit === "string"
+					? req.query.limit
+					: String(DEFAULT_LIMIT);
+			const page = Number.parseInt(pageParam, DECIMAL_RADIX);
+			const limit = Number.parseInt(limitParam, DECIMAL_RADIX);
+
+			const result = await listUsersByDateRange(
+				dateParams.start,
+				dateParams.end,
+				page,
+				limit,
+			);
+			res.json({ success: true, data: result.users, total: result.total });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
 			res
-				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-				.json({ error: dateParams.error });
-			return;
+				.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+				.json({ error: `Failed to list users: ${message}` });
 		}
-
-		const pageParam =
-			typeof req.query.page === "string"
-				? req.query.page
-				: String(DEFAULT_PAGE);
-		const limitParam =
-			typeof req.query.limit === "string"
-				? req.query.limit
-				: String(DEFAULT_LIMIT);
-		const page = Number.parseInt(pageParam, DECIMAL_RADIX);
-		const limit = Number.parseInt(limitParam, DECIMAL_RADIX);
-
-		const result = await listUsersByDateRange(
-			dateParams.start,
-			dateParams.end,
-			page,
-			limit,
-		);
-		res.json({ success: true, data: result.users, total: result.total });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
-			.json({ error: `Failed to list users: ${message}` });
-	}
-});
+	},
+);
 
 /**
  * GET /api/admin/users/:id
  * Get a single user by ID
  */
-adminRouter.get("/users/:id", async (req: Request, res: Response) => {
-	try {
-		const user = await getUserById(req.params.id);
+adminRouter.get(
+	"/users/:id",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			const user = await getUserById(req.params.id);
 
-		if (user === null) {
+			if (user === null) {
+				res
+					.status(HTTP_STATUS.CLIENT_ERROR.NOT_FOUND)
+					.json({ error: "User not found" });
+				return;
+			}
+
+			res.json({ success: true, data: user });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
 			res
-				.status(HTTP_STATUS.CLIENT_ERROR.NOT_FOUND)
-				.json({ error: "User not found" });
-			return;
+				.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+				.json({ error: `Failed to get user: ${message}` });
 		}
-
-		res.json({ success: true, data: user });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
-			.json({ error: `Failed to get user: ${message}` });
-	}
-});
+	},
+);
 
 /**
  * PUT /api/admin/users/:id
  * Update user details
  */
-adminRouter.put("/users/:id", async (req: Request, res: Response) => {
-	try {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
-		const updates: UpdateUserRequest = req.body;
-		const user = await updateUser(req.params.id, updates);
-		res.json({ success: true, data: user });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to update user: ${message}` });
-	}
-});
+adminRouter.put(
+	"/users/:id",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
+			const updates: UpdateUserRequest = req.body;
+			const user = await updateUser(req.params.id, updates);
+			res.json({ success: true, data: user });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to update user: ${message}` });
+		}
+	},
+);
 
 /**
  * POST /api/admin/users/:id/disable
  * Disable a user
  */
-adminRouter.post("/users/:id/disable", async (req: Request, res: Response) => {
-	try {
-		// Prevent users from disabling themselves
-		if (req.params.id === req.user?.id) {
-			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
-				success: false,
-				error: "Cannot disable your own account",
-			});
-			return;
-		}
+adminRouter.post(
+	"/users/:id/disable",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			// Prevent users from disabling themselves
+			if (req.params.id === req.user?.id) {
+				res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+					success: false,
+					error: "Cannot disable your own account",
+				});
+				return;
+			}
 
-		const user = await disableUser(req.params.id);
-		res.json({ success: true, data: user });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to disable user: ${message}` });
-	}
-});
+			const user = await disableUser(req.params.id);
+			res.json({ success: true, data: user });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to disable user: ${message}` });
+		}
+	},
+);
 
 /**
  * POST /api/admin/users/:id/enable
  * Enable a user
  */
-adminRouter.post("/users/:id/enable", async (req: Request, res: Response) => {
-	try {
-		const user = await enableUser(req.params.id);
-		res.json({ success: true, data: user });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to enable user: ${message}` });
-	}
-});
+adminRouter.post(
+	"/users/:id/enable",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			const user = await enableUser(req.params.id);
+			res.json({ success: true, data: user });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to enable user: ${message}` });
+		}
+	},
+);
 
 /**
  * DELETE /api/admin/users/:id
  * Delete a single user (cannot delete admins)
  */
-adminRouter.delete("/users/:id", async (req: Request, res: Response) => {
-	try {
-		await deleteUser(req.params.id);
-		res.json({ success: true });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		const status = message.includes("not found")
-			? HTTP_STATUS.CLIENT_ERROR.NOT_FOUND
-			: HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST;
-		res.status(status).json({ error: `Failed to delete user: ${message}` });
-	}
-});
+adminRouter.delete(
+	"/users/:id",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			await deleteUser(req.params.id);
+			res.json({ success: true });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			const status = message.includes("not found")
+				? HTTP_STATUS.CLIENT_ERROR.NOT_FOUND
+				: HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST;
+			res.status(status).json({ error: `Failed to delete user: ${message}` });
+		}
+	},
+);
 
 /**
  * POST /api/admin/users/bulk-delete
  * Bulk delete users by IDs (cannot delete admins)
  * Body: { userIds: string[] }
  */
-adminRouter.post("/users/bulk-delete", async (req: Request, res: Response) => {
-	try {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
-		const body: { userIds?: string[] } = req.body;
+adminRouter.post(
+	"/users/bulk-delete",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
+			const body: { userIds?: string[] } = req.body;
 
-		if (!Array.isArray(body.userIds)) {
+			if (!Array.isArray(body.userIds)) {
+				res
+					.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+					.json({ error: "userIds must be an array" });
+				return;
+			}
+
+			const result = await bulkDeleteUsers(body.userIds);
+			res.json({
+				success: true,
+				data: {
+					deleted: result.deleted,
+					skipped: result.skipped,
+					skippedAdmins: result.skippedAdmins,
+				},
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
 			res
-				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-				.json({ error: "userIds must be an array" });
-			return;
+				.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+				.json({ error: `Failed to delete users: ${message}` });
 		}
-
-		const result = await bulkDeleteUsers(body.userIds);
-		res.json({
-			success: true,
-			data: {
-				deleted: result.deleted,
-				skipped: result.skipped,
-				skippedAdmins: result.skippedAdmins,
-			},
-		});
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
-			.json({ error: `Failed to delete users: ${message}` });
-	}
-});
+	},
+);
 
 /**
  * POST /api/admin/users/:id/reset-password
@@ -490,6 +529,7 @@ adminRouter.post("/users/bulk-delete", async (req: Request, res: Response) => {
  */
 adminRouter.post(
 	"/users/:id/reset-password",
+	requireAdmin,
 	async (req: Request, res: Response) => {
 		try {
 			const user = await getUserById(req.params.id);
@@ -524,6 +564,7 @@ adminRouter.post(
  */
 adminRouter.post(
 	"/users/generate-passwords",
+	requireAdmin,
 	async (req: Request, res: Response) => {
 		try {
 			// Extract optional filter parameters from request body
@@ -559,17 +600,21 @@ adminRouter.post(
  * GET /api/admin/settings
  * Get system settings
  */
-adminRouter.get("/settings", async (req: Request, res: Response) => {
-	try {
-		const settings = await getSystemSettings();
-		res.json({ success: true, data: settings });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
-			.json({ error: `Failed to get settings: ${message}` });
-	}
-});
+adminRouter.get(
+	"/settings",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			const settings = await getSystemSettings();
+			res.json({ success: true, data: settings });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+				.json({ error: `Failed to get settings: ${message}` });
+		}
+	},
+);
 
 /**
  * PUT /api/admin/settings/login-enabled
@@ -577,6 +622,7 @@ adminRouter.get("/settings", async (req: Request, res: Response) => {
  */
 adminRouter.put(
 	"/settings/login-enabled",
+	requireAdmin,
 	async (req: Request, res: Response) => {
 		try {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- Express req.body is any
@@ -613,6 +659,7 @@ adminRouter.put(
  */
 adminRouter.post(
 	"/pools/upload",
+	requireAdmin,
 	upload.single("file"),
 	async (req: Request, res: Response) => {
 		try {
@@ -643,7 +690,7 @@ adminRouter.post(
  * GET /api/admin/pools
  * List all pools with pagination
  */
-adminRouter.get("/pools", async (req: Request, res: Response) => {
+adminRouter.get("/pools", requireAdmin, async (req: Request, res: Response) => {
 	try {
 		const pageParam =
 			typeof req.query.page === "string"
@@ -681,84 +728,92 @@ adminRouter.get("/pools", async (req: Request, res: Response) => {
  * POST /api/admin/pools
  * Create a single pool
  */
-adminRouter.post("/pools", async (req: Request, res: Response) => {
-	try {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
-		const request: CreatePoolRequest = req.body;
+adminRouter.post(
+	"/pools",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
+			const request: CreatePoolRequest = req.body;
 
-		// Validate required fields
-		if (isEmptyString(request.poolKey) || isEmptyString(request.poolName)) {
-			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
-				error: "Missing required fields: poolKey, poolName",
-			});
-			return;
+			// Validate required fields
+			if (isEmptyString(request.poolKey) || isEmptyString(request.poolName)) {
+				res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+					error: "Missing required fields: poolKey, poolName",
+				});
+				return;
+			}
+
+			// Trim whitespace from validated fields
+			const trimmedRequest: CreatePoolRequest = {
+				...request,
+				poolKey: request.poolKey.trim(),
+				poolName: request.poolName.trim(),
+			};
+
+			// Validate pool key format
+			const poolKeyError = validatePoolKeyFormat(trimmedRequest.poolKey);
+			if (poolKeyError !== undefined) {
+				res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+					error: poolKeyError,
+				});
+				return;
+			}
+
+			const pool = await createPool(trimmedRequest);
+			res
+				.status(HTTP_STATUS.SUCCESSFUL.CREATED)
+				.json({ success: true, data: pool });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to create pool: ${message}` });
 		}
-
-		// Trim whitespace from validated fields
-		const trimmedRequest: CreatePoolRequest = {
-			...request,
-			poolKey: request.poolKey.trim(),
-			poolName: request.poolName.trim(),
-		};
-
-		// Validate pool key format
-		const poolKeyError = validatePoolKeyFormat(trimmedRequest.poolKey);
-		if (poolKeyError !== undefined) {
-			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
-				error: poolKeyError,
-			});
-			return;
-		}
-
-		const pool = await createPool(trimmedRequest);
-		res
-			.status(HTTP_STATUS.SUCCESSFUL.CREATED)
-			.json({ success: true, data: pool });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to create pool: ${message}` });
-	}
-});
+	},
+);
 
 /**
  * GET /api/admin/pools/pending
  * List pending (missing) pool keys with user counts
  */
-adminRouter.get("/pools/pending", async (req: Request, res: Response) => {
-	try {
-		const pageParam =
-			typeof req.query.page === "string"
-				? req.query.page
-				: String(DEFAULT_PAGE);
-		const limitParam =
-			typeof req.query.limit === "string"
-				? req.query.limit
-				: String(DEFAULT_LIMIT);
-		const page = Number.parseInt(pageParam, DECIMAL_RADIX);
-		const limit = Number.parseInt(limitParam, DECIMAL_RADIX);
+adminRouter.get(
+	"/pools/pending",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			const pageParam =
+				typeof req.query.page === "string"
+					? req.query.page
+					: String(DEFAULT_PAGE);
+			const limitParam =
+				typeof req.query.limit === "string"
+					? req.query.limit
+					: String(DEFAULT_LIMIT);
+			const page = Number.parseInt(pageParam, DECIMAL_RADIX);
+			const limit = Number.parseInt(limitParam, DECIMAL_RADIX);
 
-		const { pendingKeys, total } = await listPendingPoolKeys(page, limit);
+			const { pendingKeys, total } = await listPendingPoolKeys(page, limit);
 
-		const response: PendingPoolKeyListResponse = {
-			data: pendingKeys,
-			pagination: {
-				page,
-				limit,
-				total,
-				totalPages: Math.ceil(total / limit),
-			},
-		};
+			const response: PendingPoolKeyListResponse = {
+				data: pendingKeys,
+				pagination: {
+					page,
+					limit,
+					total,
+					totalPages: Math.ceil(total / limit),
+				},
+			};
 
-		res.json(response);
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
-			.json({ error: `Failed to list pending pool keys: ${message}` });
-	}
-});
+			res.json(response);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+				.json({ error: `Failed to list pending pool keys: ${message}` });
+		}
+	},
+);
 
 /**
  * POST /api/admin/pools/pending/create
@@ -766,6 +821,7 @@ adminRouter.get("/pools/pending", async (req: Request, res: Response) => {
  */
 adminRouter.post(
 	"/pools/pending/create",
+	requireAdmin,
 	async (req: Request, res: Response) => {
 		try {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
@@ -814,6 +870,7 @@ adminRouter.post(
  */
 adminRouter.post(
 	"/pools/pending/remap",
+	requireAdmin,
 	async (req: Request, res: Response) => {
 		try {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
@@ -855,6 +912,7 @@ adminRouter.post(
  */
 adminRouter.delete(
 	"/pools/pending/:poolKey",
+	requireAdmin,
 	async (req: Request, res: Response) => {
 		try {
 			// eslint-disable-next-line @typescript-eslint/prefer-destructuring -- Already using destructuring
@@ -879,132 +937,152 @@ adminRouter.delete(
  * GET /api/admin/pools/:id
  * Get a single pool by ID
  */
-adminRouter.get("/pools/:id", async (req: Request, res: Response) => {
-	try {
-		const poolId = parseInt(req.params.id, 10);
-		const pool = await getPoolById(poolId);
+adminRouter.get(
+	"/pools/:id",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			const poolId = parseInt(req.params.id, 10);
+			const pool = await getPoolById(poolId);
 
-		if (pool === null) {
+			if (pool === null) {
+				res
+					.status(HTTP_STATUS.CLIENT_ERROR.NOT_FOUND)
+					.json({ error: "Pool not found" });
+				return;
+			}
+
+			res.json({ success: true, data: pool });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
 			res
-				.status(HTTP_STATUS.CLIENT_ERROR.NOT_FOUND)
-				.json({ error: "Pool not found" });
-			return;
+				.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+				.json({ error: `Failed to get pool: ${message}` });
 		}
-
-		res.json({ success: true, data: pool });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
-			.json({ error: `Failed to get pool: ${message}` });
-	}
-});
+	},
+);
 
 /**
  * PUT /api/admin/pools/:id
  * Update pool details
  */
-adminRouter.put("/pools/:id", async (req: Request, res: Response) => {
-	try {
-		const poolId = parseInt(req.params.id, 10);
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
-		const updates: UpdatePoolRequest = req.body;
+adminRouter.put(
+	"/pools/:id",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			const poolId = parseInt(req.params.id, 10);
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
+			const updates: UpdatePoolRequest = req.body;
 
-		// Validate pool key format if being updated
-		if (updates.poolKey !== undefined) {
-			const trimmedPoolKey = updates.poolKey.trim();
-			const poolKeyError = validatePoolKeyFormat(trimmedPoolKey);
-			if (poolKeyError !== undefined) {
-				res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
-					error: poolKeyError,
-				});
-				return;
+			// Validate pool key format if being updated
+			if (updates.poolKey !== undefined) {
+				const trimmedPoolKey = updates.poolKey.trim();
+				const poolKeyError = validatePoolKeyFormat(trimmedPoolKey);
+				if (poolKeyError !== undefined) {
+					res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+						error: poolKeyError,
+					});
+					return;
+				}
+				updates.poolKey = trimmedPoolKey;
 			}
-			updates.poolKey = trimmedPoolKey;
-		}
 
-		const pool = await updatePool(poolId, updates);
-		res.json({ success: true, data: pool });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to update pool: ${message}` });
-	}
-});
+			const pool = await updatePool(poolId, updates);
+			res.json({ success: true, data: pool });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to update pool: ${message}` });
+		}
+	},
+);
 
 /**
  * POST /api/admin/pools/:id/disable
  * Disable a pool
  */
-adminRouter.post("/pools/:id/disable", async (req: Request, res: Response) => {
-	try {
-		const poolId = parseInt(req.params.id, 10);
-		const pool = await disablePool(poolId);
-		res.json({ success: true, data: pool });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to disable pool: ${message}` });
-	}
-});
+adminRouter.post(
+	"/pools/:id/disable",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			const poolId = parseInt(req.params.id, 10);
+			const pool = await disablePool(poolId);
+			res.json({ success: true, data: pool });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to disable pool: ${message}` });
+		}
+	},
+);
 
 /**
  * POST /api/admin/pools/:id/enable
  * Enable a pool
  */
-adminRouter.post("/pools/:id/enable", async (req: Request, res: Response) => {
-	try {
-		const poolId = parseInt(req.params.id, 10);
-		const pool = await enablePool(poolId);
-		res.json({ success: true, data: pool });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to enable pool: ${message}` });
-	}
-});
+adminRouter.post(
+	"/pools/:id/enable",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			const poolId = parseInt(req.params.id, 10);
+			const pool = await enablePool(poolId);
+			res.json({ success: true, data: pool });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to enable pool: ${message}` });
+		}
+	},
+);
 
 /**
  * GET /api/admin/pools/:id/users
  * Get users in a pool
  */
-adminRouter.get("/pools/:id/users", async (req: Request, res: Response) => {
-	try {
-		const poolId = parseInt(req.params.id, 10);
-		const pageParam =
-			typeof req.query.page === "string"
-				? req.query.page
-				: String(DEFAULT_PAGE);
-		const limitParam =
-			typeof req.query.limit === "string"
-				? req.query.limit
-				: String(DEFAULT_LIMIT);
-		const page = Number.parseInt(pageParam, DECIMAL_RADIX);
-		const limit = Number.parseInt(limitParam, DECIMAL_RADIX);
+adminRouter.get(
+	"/pools/:id/users",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			const poolId = parseInt(req.params.id, 10);
+			const pageParam =
+				typeof req.query.page === "string"
+					? req.query.page
+					: String(DEFAULT_PAGE);
+			const limitParam =
+				typeof req.query.limit === "string"
+					? req.query.limit
+					: String(DEFAULT_LIMIT);
+			const page = Number.parseInt(pageParam, DECIMAL_RADIX);
+			const limit = Number.parseInt(limitParam, DECIMAL_RADIX);
 
-		const { users, total } = await getUsersInPool(poolId, page, limit);
+			const { users, total } = await getUsersInPool(poolId, page, limit);
 
-		const response: UserListResponse = {
-			data: users,
-			pagination: {
-				page,
-				limit,
-				total,
-				totalPages: Math.ceil(total / limit),
-			},
-		};
+			const response: UserListResponse = {
+				data: users,
+				pagination: {
+					page,
+					limit,
+					total,
+					totalPages: Math.ceil(total / limit),
+				},
+			};
 
-		res.json(response);
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
-			.json({ error: `Failed to get pool users: ${message}` });
-	}
-});
+			res.json(response);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+				.json({ error: `Failed to get pool users: ${message}` });
+		}
+	},
+);
 
 /**
  * POST /api/admin/pools/:id/users/:userId
@@ -1012,6 +1090,7 @@ adminRouter.get("/pools/:id/users", async (req: Request, res: Response) => {
  */
 adminRouter.post(
 	"/pools/:id/users/:userId",
+	requireAdmin,
 	async (req: Request, res: Response) => {
 		try {
 			const {
@@ -1036,6 +1115,7 @@ adminRouter.post(
  */
 adminRouter.delete(
 	"/pools/:id/users/:userId",
+	requireAdmin,
 	async (req: Request, res: Response) => {
 		try {
 			const {
@@ -1078,20 +1158,24 @@ adminRouter.delete(
  * GET /api/admin/users/:id/pools
  * Get pools for a user
  */
-adminRouter.get("/users/:id/pools", async (req: Request, res: Response) => {
-	try {
-		const {
-			params: { id },
-		} = req;
-		const pools = await getPoolsForUser(id);
-		res.json({ success: true, data: pools });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
-			.json({ error: `Failed to get user pools: ${message}` });
-	}
-});
+adminRouter.get(
+	"/users/:id/pools",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			const {
+				params: { id },
+			} = req;
+			const pools = await getPoolsForUser(id);
+			res.json({ success: true, data: pools });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+				.json({ error: `Failed to get user pools: ${message}` });
+		}
+	},
+);
 
 /**
  * Meeting Management Routes
@@ -1101,50 +1185,54 @@ adminRouter.get("/users/:id/pools", async (req: Request, res: Response) => {
  * POST /api/admin/meetings
  * Create a new meeting
  */
-adminRouter.post("/meetings", async (req: Request, res: Response) => {
-	try {
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
-		const request: Partial<CreateMeetingRequest> = req.body;
+adminRouter.post(
+	"/meetings",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
+			const request: Partial<CreateMeetingRequest> = req.body;
 
-		// Validate required fields
-		if (
-			request.name === undefined ||
-			request.name === "" ||
-			request.startDate === undefined ||
-			request.startDate === "" ||
-			request.endDate === undefined ||
-			request.endDate === "" ||
-			request.quorumVotingPoolId === undefined
-		) {
-			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
-				error:
-					"Missing required fields: name, startDate, endDate, quorumVotingPoolId",
-			});
-			return;
+			// Validate required fields
+			if (
+				request.name === undefined ||
+				request.name === "" ||
+				request.startDate === undefined ||
+				request.startDate === "" ||
+				request.endDate === undefined ||
+				request.endDate === "" ||
+				request.quorumVotingPoolId === undefined
+			) {
+				res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+					error:
+						"Missing required fields: name, startDate, endDate, quorumVotingPoolId",
+				});
+				return;
+			}
+
+			// After validation, we know all required fields exist
+			const validatedRequest: CreateMeetingRequest = {
+				name: request.name,
+				startDate: request.startDate,
+				endDate: request.endDate,
+				quorumVotingPoolId: request.quorumVotingPoolId,
+				watcherPoolId: request.watcherPoolId,
+				adminPoolId: request.adminPoolId,
+				description: request.description,
+			};
+
+			const meeting = await createMeeting(validatedRequest);
+			res
+				.status(HTTP_STATUS.SUCCESSFUL.CREATED)
+				.json({ success: true, data: meeting });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to create meeting: ${message}` });
 		}
-
-		// After validation, we know all required fields exist
-		const validatedRequest: CreateMeetingRequest = {
-			name: request.name,
-			startDate: request.startDate,
-			endDate: request.endDate,
-			quorumVotingPoolId: request.quorumVotingPoolId,
-			watcherPoolId: request.watcherPoolId,
-			adminPoolId: request.adminPoolId,
-			description: request.description,
-		};
-
-		const meeting = await createMeeting(validatedRequest);
-		res
-			.status(HTTP_STATUS.SUCCESSFUL.CREATED)
-			.json({ success: true, data: meeting });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to create meeting: ${message}` });
-	}
-});
+	},
+);
 
 /**
  * GET /api/admin/meetings
@@ -1294,99 +1382,121 @@ adminRouter.post("/meetings/leave", async (req: Request, res: Response) => {
  * GET /api/admin/meetings/:id
  * Get a single meeting by ID
  */
-adminRouter.get("/meetings/:id", async (req: Request, res: Response) => {
-	try {
-		const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
-		const meeting = await getMeetingById(meetingId);
+adminRouter.get(
+	"/meetings/:id",
+	requireMeetingAdmin("id"),
+	async (req: Request, res: Response) => {
+		try {
+			const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
+			const meeting = await getMeetingById(meetingId);
 
-		if (meeting === null) {
+			if (meeting === null) {
+				res
+					.status(HTTP_STATUS.CLIENT_ERROR.NOT_FOUND)
+					.json({ error: "Meeting not found" });
+				return;
+			}
+
+			res.json({ success: true, data: meeting });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
 			res
-				.status(HTTP_STATUS.CLIENT_ERROR.NOT_FOUND)
-				.json({ error: "Meeting not found" });
-			return;
+				.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+				.json({ error: `Failed to get meeting: ${message}` });
 		}
-
-		res.json({ success: true, data: meeting });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
-			.json({ error: `Failed to get meeting: ${message}` });
-	}
-});
+	},
+);
 
 /**
  * PUT /api/admin/meetings/:id
  * Update meeting details
  */
-adminRouter.put("/meetings/:id", async (req: Request, res: Response) => {
-	try {
-		const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
-		const updates: UpdateMeetingRequest = req.body;
-		const meeting = await updateMeeting(meetingId, updates);
-		res.json({ success: true, data: meeting });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to update meeting: ${message}` });
-	}
-});
+adminRouter.put(
+	"/meetings/:id",
+	requireMeetingAdmin("id"),
+	async (req: Request, res: Response) => {
+		try {
+			const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
+			const updates: UpdateMeetingRequest = req.body;
+			// Only global admins may change the admin pool for a meeting.
+			// Strip adminPoolId from the update payload for non-global-admins so a
+			// scoped meeting admin can't grant admin rights to others.
+			if (req.user?.isAdmin !== true && "adminPoolId" in updates) {
+				delete updates.adminPoolId;
+			}
+			const meeting = await updateMeeting(meetingId, updates);
+			res.json({ success: true, data: meeting });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to update meeting: ${message}` });
+		}
+	},
+);
 
 /**
  * DELETE /api/admin/meetings/:id
  * Delete a meeting (cascades to motions and choices)
  */
-adminRouter.delete("/meetings/:id", async (req: Request, res: Response) => {
-	try {
-		const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
-		await deleteMeeting(meetingId);
-		res.json({ success: true, message: "Meeting deleted successfully" });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to delete meeting: ${message}` });
-	}
-});
+adminRouter.delete(
+	"/meetings/:id",
+	requireAdmin,
+	async (req: Request, res: Response) => {
+		try {
+			const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
+			await deleteMeeting(meetingId);
+			res.json({ success: true, message: "Meeting deleted successfully" });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to delete meeting: ${message}` });
+		}
+	},
+);
 
 /**
  * POST /api/admin/meetings/:id/join
  * Join a meeting as meeting admin
  */
-adminRouter.post("/meetings/:id/join", async (req: Request, res: Response) => {
-	try {
-		if (req.user === undefined) {
-			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
-				success: false,
-				error: "Authentication required",
-			});
-			return;
-		}
+adminRouter.post(
+	"/meetings/:id/join",
+	requireMeetingAdmin("id"),
+	async (req: Request, res: Response) => {
+		try {
+			if (req.user === undefined) {
+				res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+					success: false,
+					error: "Authentication required",
+				});
+				return;
+			}
 
-		const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
-		if (Number.isNaN(meetingId)) {
-			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
-				success: false,
-				error: "Invalid meeting ID",
-			});
-			return;
-		}
+			const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
+			if (Number.isNaN(meetingId)) {
+				res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+					success: false,
+					error: "Invalid meeting ID",
+				});
+				return;
+			}
 
-		const result = await joinMeetingAsAdmin(
-			req.user.id,
-			meetingId,
-			req.user.isAdmin,
-		);
-		res.json({ success: true, data: result });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
-			.json({ success: false, error: `Failed to join meeting: ${message}` });
-	}
-});
+			const result = await joinMeetingAsAdmin(
+				req.user.id,
+				meetingId,
+				req.user.isAdmin,
+			);
+			res.json({ success: true, data: result });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+				.json({ success: false, error: `Failed to join meeting: ${message}` });
+		}
+	},
+);
 
 /**
  * Motion Management Routes
@@ -1398,6 +1508,7 @@ adminRouter.post("/meetings/:id/join", async (req: Request, res: Response) => {
  */
 adminRouter.post(
 	"/meetings/:meetingId/motions",
+	requireMeetingAdmin("meetingId"),
 	async (req: Request, res: Response) => {
 		try {
 			const meetingId = parseInt(req.params.meetingId, DECIMAL_RADIX);
@@ -1444,6 +1555,7 @@ adminRouter.post(
  */
 adminRouter.get(
 	"/meetings/:meetingId/motions",
+	requireMeetingAdmin("meetingId"),
 	async (req: Request, res: Response) => {
 		try {
 			const meetingId = parseInt(req.params.meetingId, DECIMAL_RADIX);
@@ -1488,26 +1600,30 @@ adminRouter.get(
  * GET /api/admin/motions/:id
  * Get a single motion by ID
  */
-adminRouter.get("/motions/:id", async (req: Request, res: Response) => {
-	try {
-		const motionId = parseInt(req.params.id, DECIMAL_RADIX);
-		const motion = await getMotionById(motionId);
+adminRouter.get(
+	"/motions/:id",
+	requireMeetingAdminForMotion("id"),
+	async (req: Request, res: Response) => {
+		try {
+			const motionId = parseInt(req.params.id, DECIMAL_RADIX);
+			const motion = await getMotionById(motionId);
 
-		if (motion === null) {
+			if (motion === null) {
+				res
+					.status(HTTP_STATUS.CLIENT_ERROR.NOT_FOUND)
+					.json({ error: "Motion not found" });
+				return;
+			}
+
+			res.json({ success: true, data: motion });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
 			res
-				.status(HTTP_STATUS.CLIENT_ERROR.NOT_FOUND)
-				.json({ error: "Motion not found" });
-			return;
+				.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+				.json({ error: `Failed to get motion: ${message}` });
 		}
-
-		res.json({ success: true, data: motion });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
-			.json({ error: `Failed to get motion: ${message}` });
-	}
-});
+	},
+);
 
 /**
  * GET /api/admin/motions/:id/vote-stats
@@ -1515,6 +1631,7 @@ adminRouter.get("/motions/:id", async (req: Request, res: Response) => {
  */
 adminRouter.get(
 	"/motions/:id/vote-stats",
+	requireMeetingAdminForMotion("id"),
 	async (req: Request, res: Response) => {
 		try {
 			const motionId = parseInt(req.params.id, DECIMAL_RADIX);
@@ -1533,75 +1650,89 @@ adminRouter.get(
  * GET /api/admin/motions/:id/results
  * Get detailed voting results for a completed motion
  */
-adminRouter.get("/motions/:id/results", async (req: Request, res: Response) => {
-	try {
-		const motionId = parseInt(req.params.id, DECIMAL_RADIX);
-		const results = await getMotionDetailedResults(motionId);
-		res.json({ success: true, data: results });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
+adminRouter.get(
+	"/motions/:id/results",
+	requireMeetingAdminForMotion("id"),
+	async (req: Request, res: Response) => {
+		try {
+			const motionId = parseInt(req.params.id, DECIMAL_RADIX);
+			const results = await getMotionDetailedResults(motionId);
+			res.json({ success: true, data: results });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
 
-		// Return 400 for "not voting_complete" errors
-		if (message.includes("voting_complete")) {
-			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({ error: message });
-		} else {
-			res
-				.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
-				.json({ error: `Failed to get motion results: ${message}` });
+			// Return 400 for "not voting_complete" errors
+			if (message.includes("voting_complete")) {
+				res
+					.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+					.json({ error: message });
+			} else {
+				res
+					.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+					.json({ error: `Failed to get motion results: ${message}` });
+			}
 		}
-	}
-});
+	},
+);
 
 /**
  * PUT /api/admin/motions/:id
  * Update motion details (non-status fields)
  */
-adminRouter.put("/motions/:id", async (req: Request, res: Response) => {
-	try {
-		const motionId = parseInt(req.params.id, DECIMAL_RADIX);
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
-		const updates: UpdateMotionRequest = req.body;
-		const motion = await updateMotion(motionId, updates);
-		res.json({ success: true, data: motion });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to update motion: ${message}` });
-	}
-});
+adminRouter.put(
+	"/motions/:id",
+	requireMeetingAdminForMotion("id"),
+	async (req: Request, res: Response) => {
+		try {
+			const motionId = parseInt(req.params.id, DECIMAL_RADIX);
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
+			const updates: UpdateMotionRequest = req.body;
+			const motion = await updateMotion(motionId, updates);
+			res.json({ success: true, data: motion });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to update motion: ${message}` });
+		}
+	},
+);
 
 /**
  * PUT /api/admin/motions/:id/status
  * Update motion status (forward-only transitions)
  */
-adminRouter.put("/motions/:id/status", async (req: Request, res: Response) => {
-	try {
-		const motionId = parseInt(req.params.id, DECIMAL_RADIX);
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
-		const body: Partial<UpdateMotionStatusRequest> = req.body;
+adminRouter.put(
+	"/motions/:id/status",
+	requireMeetingAdminForMotion("id"),
+	async (req: Request, res: Response) => {
+		try {
+			const motionId = parseInt(req.params.id, DECIMAL_RADIX);
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
+			const body: Partial<UpdateMotionStatusRequest> = req.body;
 
-		if (body.status === undefined) {
-			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
-				error: "Missing required field: status",
-			});
-			return;
+			if (body.status === undefined) {
+				res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+					error: "Missing required field: status",
+				});
+				return;
+			}
+
+			const request: UpdateMotionStatusRequest = {
+				status: body.status,
+				endOverride: body.endOverride,
+			};
+
+			const motion = await updateMotionStatus(motionId, request);
+			res.json({ success: true, data: motion });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to update motion status: ${message}` });
 		}
-
-		const request: UpdateMotionStatusRequest = {
-			status: body.status,
-			endOverride: body.endOverride,
-		};
-
-		const motion = await updateMotionStatus(motionId, request);
-		res.json({ success: true, data: motion });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to update motion status: ${message}` });
-	}
-});
+	},
+);
 
 /**
  * PUT /api/admin/motions/:id/end-override
@@ -1609,6 +1740,7 @@ adminRouter.put("/motions/:id/status", async (req: Request, res: Response) => {
  */
 adminRouter.put(
 	"/motions/:id/end-override",
+	requireMeetingAdminForMotion("id"),
 	async (req: Request, res: Response) => {
 		try {
 			const motionId = parseInt(req.params.id, DECIMAL_RADIX);
@@ -1630,18 +1762,22 @@ adminRouter.put(
  * DELETE /api/admin/motions/:id
  * Delete a motion (cascades to choices)
  */
-adminRouter.delete("/motions/:id", async (req: Request, res: Response) => {
-	try {
-		const motionId = parseInt(req.params.id, DECIMAL_RADIX);
-		await deleteMotion(motionId);
-		res.json({ success: true, message: "Motion deleted successfully" });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to delete motion: ${message}` });
-	}
-});
+adminRouter.delete(
+	"/motions/:id",
+	requireMeetingAdminForMotion("id"),
+	async (req: Request, res: Response) => {
+		try {
+			const motionId = parseInt(req.params.id, DECIMAL_RADIX);
+			await deleteMotion(motionId);
+			res.json({ success: true, message: "Motion deleted successfully" });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to delete motion: ${message}` });
+		}
+	},
+);
 
 /**
  * Choice Management Routes
@@ -1653,6 +1789,7 @@ adminRouter.delete("/motions/:id", async (req: Request, res: Response) => {
  */
 adminRouter.post(
 	"/motions/:motionId/choices",
+	requireMeetingAdminForMotion("motionId"),
 	async (req: Request, res: Response) => {
 		try {
 			const motionId = parseInt(req.params.motionId, DECIMAL_RADIX);
@@ -1693,6 +1830,7 @@ adminRouter.post(
  */
 adminRouter.get(
 	"/motions/:motionId/choices",
+	requireMeetingAdminForMotion("motionId"),
 	async (req: Request, res: Response) => {
 		try {
 			const motionId = parseInt(req.params.motionId, DECIMAL_RADIX);
@@ -1716,45 +1854,53 @@ adminRouter.get(
  * GET /api/admin/choices/:id
  * Get a single choice by ID
  */
-adminRouter.get("/choices/:id", async (req: Request, res: Response) => {
-	try {
-		const choiceId = parseInt(req.params.id, DECIMAL_RADIX);
-		const choice = await getChoiceById(choiceId);
+adminRouter.get(
+	"/choices/:id",
+	requireMeetingAdminForChoice("id"),
+	async (req: Request, res: Response) => {
+		try {
+			const choiceId = parseInt(req.params.id, DECIMAL_RADIX);
+			const choice = await getChoiceById(choiceId);
 
-		if (choice === null) {
+			if (choice === null) {
+				res
+					.status(HTTP_STATUS.CLIENT_ERROR.NOT_FOUND)
+					.json({ error: "Choice not found" });
+				return;
+			}
+
+			res.json({ success: true, data: choice });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
 			res
-				.status(HTTP_STATUS.CLIENT_ERROR.NOT_FOUND)
-				.json({ error: "Choice not found" });
-			return;
+				.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+				.json({ error: `Failed to get choice: ${message}` });
 		}
-
-		res.json({ success: true, data: choice });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
-			.json({ error: `Failed to get choice: ${message}` });
-	}
-});
+	},
+);
 
 /**
  * PUT /api/admin/choices/:id
  * Update a choice (only if motion not started)
  */
-adminRouter.put("/choices/:id", async (req: Request, res: Response) => {
-	try {
-		const choiceId = parseInt(req.params.id, DECIMAL_RADIX);
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
-		const updates: UpdateChoiceRequest = req.body;
-		const choice = await updateChoice(choiceId, updates);
-		res.json({ success: true, data: choice });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to update choice: ${message}` });
-	}
-});
+adminRouter.put(
+	"/choices/:id",
+	requireMeetingAdminForChoice("id"),
+	async (req: Request, res: Response) => {
+		try {
+			const choiceId = parseInt(req.params.id, DECIMAL_RADIX);
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
+			const updates: UpdateChoiceRequest = req.body;
+			const choice = await updateChoice(choiceId, updates);
+			res.json({ success: true, data: choice });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to update choice: ${message}` });
+		}
+	},
+);
 
 /**
  * PUT /api/admin/motions/:motionId/choices/reorder
@@ -1762,6 +1908,7 @@ adminRouter.put("/choices/:id", async (req: Request, res: Response) => {
  */
 adminRouter.put(
 	"/motions/:motionId/choices/reorder",
+	requireMeetingAdminForMotion("motionId"),
 	async (req: Request, res: Response) => {
 		try {
 			const motionId = parseInt(req.params.motionId, DECIMAL_RADIX);
@@ -1790,18 +1937,22 @@ adminRouter.put(
  * DELETE /api/admin/choices/:id
  * Delete a choice (only if motion not started)
  */
-adminRouter.delete("/choices/:id", async (req: Request, res: Response) => {
-	try {
-		const choiceId = parseInt(req.params.id, DECIMAL_RADIX);
-		await deleteChoice(choiceId);
-		res.json({ success: true, message: "Choice deleted successfully" });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to delete choice: ${message}` });
-	}
-});
+adminRouter.delete(
+	"/choices/:id",
+	requireMeetingAdminForChoice("id"),
+	async (req: Request, res: Response) => {
+		try {
+			const choiceId = parseInt(req.params.id, DECIMAL_RADIX);
+			await deleteChoice(choiceId);
+			res.json({ success: true, message: "Choice deleted successfully" });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to delete choice: ${message}` });
+		}
+	},
+);
 
 /**
  * Quorum Management Routes
@@ -1811,51 +1962,60 @@ adminRouter.delete("/choices/:id", async (req: Request, res: Response) => {
  * GET /api/admin/meetings/:id/quorum
  * Get quorum report for a meeting
  */
-adminRouter.get("/meetings/:id/quorum", async (req: Request, res: Response) => {
-	try {
-		const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
-		const report = await getQuorumReport(meetingId);
+adminRouter.get(
+	"/meetings/:id/quorum",
+	requireMeetingAdmin("id"),
+	async (req: Request, res: Response) => {
+		try {
+			const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
+			const report = await getQuorumReport(meetingId);
 
-		if (report === null) {
+			if (report === null) {
+				res
+					.status(HTTP_STATUS.CLIENT_ERROR.NOT_FOUND)
+					.json({ error: "Meeting not found" });
+				return;
+			}
+
+			res.json({ success: true, data: report });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
 			res
-				.status(HTTP_STATUS.CLIENT_ERROR.NOT_FOUND)
-				.json({ error: "Meeting not found" });
-			return;
+				.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
+				.json({ error: `Failed to get quorum report: ${message}` });
 		}
-
-		res.json({ success: true, data: report });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
-			.json({ error: `Failed to get quorum report: ${message}` });
-	}
-});
+	},
+);
 
 /**
  * PUT /api/admin/meetings/:id/quorum
  * Call or uncall quorum for a meeting
  */
-adminRouter.put("/meetings/:id/quorum", async (req: Request, res: Response) => {
-	try {
-		const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- Express req.body is any
-		const quorumCalledAt: string | null = req.body.quorumCalledAt ?? null;
+adminRouter.put(
+	"/meetings/:id/quorum",
+	requireMeetingAdmin("id"),
+	async (req: Request, res: Response) => {
+		try {
+			const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access -- Express req.body is any
+			const quorumCalledAt: string | null = req.body.quorumCalledAt ?? null;
 
-		const timestamp = quorumCalledAt === null ? null : new Date(quorumCalledAt);
+			const timestamp =
+				quorumCalledAt === null ? null : new Date(quorumCalledAt);
 
-		await callQuorum(meetingId, timestamp);
+			await callQuorum(meetingId, timestamp);
 
-		// Return updated quorum report
-		const report = await getQuorumReport(meetingId);
-		res.json({ success: true, data: report });
-	} catch (error) {
-		const message = error instanceof Error ? error.message : "Unknown error";
-		res
-			.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-			.json({ error: `Failed to update quorum: ${message}` });
-	}
-});
+			// Return updated quorum report
+			const report = await getQuorumReport(meetingId);
+			res.json({ success: true, data: report });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res
+				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+				.json({ error: `Failed to update quorum: ${message}` });
+		}
+	},
+);
 
 /**
  * GET /api/admin/meetings/:id/quorum/voters
@@ -1863,6 +2023,7 @@ adminRouter.put("/meetings/:id/quorum", async (req: Request, res: Response) => {
  */
 adminRouter.get(
 	"/meetings/:id/quorum/voters",
+	requireMeetingAdmin("id"),
 	async (req: Request, res: Response) => {
 		try {
 			const meetingId = parseInt(req.params.id, DECIMAL_RADIX);

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -6,6 +6,7 @@ import { HTTP_STATUS } from "@pdc/http-status-codes";
 import { LoginErrorCode } from "@mcdc-convention-voting/shared";
 import { validateLogin, generateToken } from "../services/auth-service.js";
 import { requireAuth } from "../middleware/auth-middleware.js";
+import { leaveCurrentMeeting } from "../services/meeting-participant-service.js";
 import type { Request, Response } from "express";
 import type {
 	LoginRequest,
@@ -85,6 +86,10 @@ authRouter.post(
 			});
 			return;
 		}
+
+		// Leave any current meeting from a previous session
+		// This ensures users start fresh and can select a new meeting
+		await leaveCurrentMeeting(result.user.id);
 
 		// Generate JWT token
 		const token = generateToken(result.user);

--- a/packages/server/src/routes/voter.ts
+++ b/packages/server/src/routes/voter.ts
@@ -4,6 +4,12 @@
 import { Router } from "express";
 import { HTTP_STATUS } from "@pdc/http-status-codes";
 import { requireVoter } from "../middleware/auth-middleware.js";
+import {
+	getCurrentMeetingInfo,
+	getJoinableMeetingsForVoter,
+	joinMeetingAsVoter,
+	leaveCurrentMeeting,
+} from "../services/meeting-participant-service.js";
 import { getOpenMotionsForUser } from "../services/motion-service.js";
 import { getPoolsForUser } from "../services/pool-service.js";
 import { castVote, getMotionForVoting } from "../services/vote-service.js";
@@ -12,6 +18,10 @@ import type {
 	ApiResponse,
 	CastVoteRequest,
 	CastVoteResponse,
+	CurrentMeetingResponse,
+	JoinableMeetingsResponse,
+	JoinMeetingResponse,
+	LeaveMeetingResponse,
 	MotionForVoting,
 	OpenMotionsResponse,
 	Pool,
@@ -22,6 +32,24 @@ const DECIMAL_RADIX = 10;
 
 // HTTP status code constant
 const HTTP_INTERNAL_SERVER_ERROR = 500;
+
+/**
+ * Determine HTTP status code for meeting join errors
+ */
+function getMeetingJoinErrorStatus(message: string): number {
+	if (
+		message.includes("not found") ||
+		message.includes("not currently active")
+	) {
+		return HTTP_STATUS.CLIENT_ERROR.NOT_FOUND;
+	}
+
+	if (message.includes("not eligible")) {
+		return HTTP_STATUS.CLIENT_ERROR.FORBIDDEN;
+	}
+
+	return HTTP_INTERNAL_SERVER_ERROR;
+}
 
 /**
  * Determine HTTP status code for vote casting errors
@@ -269,6 +297,171 @@ voterRouter.post(
 			res.status(statusCode).json({
 				success: false,
 				error: errorMessage,
+			});
+		}
+	},
+);
+
+// ============================================================================
+// Meeting Participation Endpoints
+// ============================================================================
+
+/**
+ * GET /api/voter/meetings/joinable
+ * Get list of active meetings the user can join as a voter
+ */
+voterRouter.get(
+	"/meetings/joinable",
+	async (
+		req: Request<object, ApiResponse<JoinableMeetingsResponse>>,
+		res: Response<ApiResponse<JoinableMeetingsResponse>>,
+	): Promise<void> => {
+		if (req.user === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+				success: false,
+				error: "Authentication required",
+			});
+			return;
+		}
+
+		try {
+			const meetings = await getJoinableMeetingsForVoter(req.user.id);
+
+			res.json({
+				success: true,
+				data: {
+					data: meetings,
+				},
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR).json({
+				success: false,
+				error: `Failed to get joinable meetings: ${message}`,
+			});
+		}
+	},
+);
+
+/**
+ * GET /api/voter/meetings/current
+ * Get the user's current active meeting
+ */
+voterRouter.get(
+	"/meetings/current",
+	async (
+		req: Request<object, ApiResponse<CurrentMeetingResponse>>,
+		res: Response<ApiResponse<CurrentMeetingResponse>>,
+	): Promise<void> => {
+		if (req.user === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+				success: false,
+				error: "Authentication required",
+			});
+			return;
+		}
+
+		try {
+			const currentMeeting = await getCurrentMeetingInfo(req.user.id);
+
+			res.json({
+				success: true,
+				data: {
+					data: currentMeeting,
+				},
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR).json({
+				success: false,
+				error: `Failed to get current meeting: ${message}`,
+			});
+		}
+	},
+);
+
+/**
+ * POST /api/voter/meetings/:id/join
+ * Join a meeting as a voter
+ * Protected by requireVoter to ensure only voters can join meetings
+ */
+voterRouter.post(
+	"/meetings/:id/join",
+	requireVoter,
+	async (
+		req: Request<{ id: string }, ApiResponse<JoinMeetingResponse>>,
+		res: Response<ApiResponse<JoinMeetingResponse>>,
+	): Promise<void> => {
+		if (req.user === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+				success: false,
+				error: "Authentication required",
+			});
+			return;
+		}
+
+		const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
+		if (Number.isNaN(meetingId)) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+				success: false,
+				error: "Invalid meeting ID",
+			});
+			return;
+		}
+
+		try {
+			const result = await joinMeetingAsVoter(req.user.id, meetingId);
+
+			res.json({
+				success: true,
+				data: {
+					data: result,
+				},
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			const statusCode = getMeetingJoinErrorStatus(message);
+
+			res.status(statusCode).json({
+				success: false,
+				error: message,
+			});
+		}
+	},
+);
+
+/**
+ * POST /api/voter/meetings/leave
+ * Leave the current meeting
+ */
+voterRouter.post(
+	"/meetings/leave",
+	async (
+		req: Request<object, ApiResponse<LeaveMeetingResponse>>,
+		res: Response<ApiResponse<LeaveMeetingResponse>>,
+	): Promise<void> => {
+		if (req.user === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+				success: false,
+				error: "Authentication required",
+			});
+			return;
+		}
+
+		try {
+			const success = await leaveCurrentMeeting(req.user.id);
+
+			res.json({
+				success: true,
+				data: {
+					data: { success },
+				},
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR).json({
+				success: false,
+				error: `Failed to leave meeting: ${message}`,
 			});
 		}
 	},

--- a/packages/server/src/routes/watcher.ts
+++ b/packages/server/src/routes/watcher.ts
@@ -25,6 +25,10 @@ import {
 	joinMeetingAsWatcher,
 	leaveCurrentMeeting,
 } from "../services/meeting-participant-service.js";
+import {
+	requireWatcherForMeeting,
+	requireWatcherForMotion,
+} from "../middleware/watcher-meeting-middleware.js";
 import type { Request, Response } from "express";
 import type {
 	ApiResponse,
@@ -288,6 +292,7 @@ watcherRouter.get(
  */
 watcherRouter.get(
 	"/meetings/:id",
+	requireWatcherForMeeting("id"),
 	async (req: Request, res: Response): Promise<void> => {
 		try {
 			const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
@@ -336,6 +341,7 @@ watcherRouter.get(
  */
 watcherRouter.get(
 	"/meetings/:id/quorum",
+	requireWatcherForMeeting("id"),
 	async (req: Request, res: Response): Promise<void> => {
 		try {
 			const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
@@ -380,6 +386,7 @@ watcherRouter.get(
  */
 watcherRouter.get(
 	"/meetings/:id/quorum/voters",
+	requireWatcherForMeeting("id"),
 	async (req: Request, res: Response): Promise<void> => {
 		try {
 			const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
@@ -420,6 +427,7 @@ watcherRouter.get(
  */
 watcherRouter.get(
 	"/motions/:id",
+	requireWatcherForMotion("id"),
 	async (req: Request, res: Response): Promise<void> => {
 		try {
 			const motionId = parseInt(req.params.id, DECIMAL_RADIX);
@@ -464,6 +472,7 @@ watcherRouter.get(
  */
 watcherRouter.get(
 	"/motions/:id/voters",
+	requireWatcherForMotion("id"),
 	async (req: Request, res: Response): Promise<void> => {
 		try {
 			const motionId = parseInt(req.params.id, DECIMAL_RADIX);
@@ -517,6 +526,7 @@ watcherRouter.get(
  */
 watcherRouter.get(
 	"/motions/:id/results",
+	requireWatcherForMotion("id"),
 	async (req: Request, res: Response): Promise<void> => {
 		try {
 			const motionId = parseInt(req.params.id, DECIMAL_RADIX);

--- a/packages/server/src/routes/watcher.ts
+++ b/packages/server/src/routes/watcher.ts
@@ -19,7 +19,20 @@ import {
 	getWatcherMotionVoters,
 	getWatcherMotionResult,
 } from "../services/watcher-service.js";
+import {
+	getCurrentMeetingInfo,
+	getJoinableMeetingsForWatcher,
+	joinMeetingAsWatcher,
+	leaveCurrentMeeting,
+} from "../services/meeting-participant-service.js";
 import type { Request, Response } from "express";
+import type {
+	ApiResponse,
+	CurrentMeetingResponse,
+	JoinableMeetingsResponse,
+	JoinMeetingResponse,
+	LeaveMeetingResponse,
+} from "@mcdc-convention-voting/shared";
 
 export const watcherRouter = Router();
 
@@ -28,17 +41,210 @@ const DEFAULT_PAGE = 1;
 const DEFAULT_LIMIT = 50;
 const DECIMAL_RADIX = 10;
 
+// HTTP status code constant
+const HTTP_INTERNAL_SERVER_ERROR = 500;
+
+/**
+ * Determine HTTP status code for meeting join errors
+ */
+function getMeetingJoinErrorStatus(message: string): number {
+	if (
+		message.includes("not found") ||
+		message.includes("not currently active") ||
+		message.includes("does not allow watchers")
+	) {
+		return HTTP_STATUS.CLIENT_ERROR.NOT_FOUND;
+	}
+
+	if (message.includes("not eligible")) {
+		return HTTP_STATUS.CLIENT_ERROR.FORBIDDEN;
+	}
+
+	return HTTP_INTERNAL_SERVER_ERROR;
+}
+
+// ============================================================================
+// Meeting Participation Endpoints
+// ============================================================================
+
+/**
+ * GET /watcher/meetings/joinable
+ * Get list of active meetings the user can join as a watcher
+ */
+watcherRouter.get(
+	"/meetings/joinable",
+	async (
+		req: Request<object, ApiResponse<JoinableMeetingsResponse>>,
+		res: Response<ApiResponse<JoinableMeetingsResponse>>,
+	): Promise<void> => {
+		if (req.user === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+				success: false,
+				error: "Authentication required",
+			});
+			return;
+		}
+
+		try {
+			const meetings = await getJoinableMeetingsForWatcher(req.user.id);
+
+			res.json({
+				success: true,
+				data: {
+					data: meetings,
+				},
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR).json({
+				success: false,
+				error: `Failed to get joinable meetings: ${message}`,
+			});
+		}
+	},
+);
+
+/**
+ * GET /watcher/meetings/current
+ * Get the user's current active meeting
+ */
+watcherRouter.get(
+	"/meetings/current",
+	async (
+		req: Request<object, ApiResponse<CurrentMeetingResponse>>,
+		res: Response<ApiResponse<CurrentMeetingResponse>>,
+	): Promise<void> => {
+		if (req.user === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+				success: false,
+				error: "Authentication required",
+			});
+			return;
+		}
+
+		try {
+			const currentMeeting = await getCurrentMeetingInfo(req.user.id);
+
+			res.json({
+				success: true,
+				data: {
+					data: currentMeeting,
+				},
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR).json({
+				success: false,
+				error: `Failed to get current meeting: ${message}`,
+			});
+		}
+	},
+);
+
+/**
+ * POST /watcher/meetings/:id/join
+ * Join a meeting as a watcher
+ */
+watcherRouter.post(
+	"/meetings/:id/join",
+	async (
+		req: Request<{ id: string }, ApiResponse<JoinMeetingResponse>>,
+		res: Response<ApiResponse<JoinMeetingResponse>>,
+	): Promise<void> => {
+		if (req.user === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+				success: false,
+				error: "Authentication required",
+			});
+			return;
+		}
+
+		const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
+		if (Number.isNaN(meetingId)) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+				success: false,
+				error: "Invalid meeting ID",
+			});
+			return;
+		}
+
+		try {
+			const result = await joinMeetingAsWatcher(req.user.id, meetingId);
+
+			res.json({
+				success: true,
+				data: {
+					data: result,
+				},
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			const statusCode = getMeetingJoinErrorStatus(message);
+
+			res.status(statusCode).json({
+				success: false,
+				error: message,
+			});
+		}
+	},
+);
+
+/**
+ * POST /watcher/meetings/leave
+ * Leave the current meeting
+ */
+watcherRouter.post(
+	"/meetings/leave",
+	async (
+		req: Request<object, ApiResponse<LeaveMeetingResponse>>,
+		res: Response<ApiResponse<LeaveMeetingResponse>>,
+	): Promise<void> => {
+		if (req.user === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+				success: false,
+				error: "Authentication required",
+			});
+			return;
+		}
+
+		try {
+			const success = await leaveCurrentMeeting(req.user.id);
+
+			res.json({
+				success: true,
+				data: {
+					data: { success },
+				},
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR).json({
+				success: false,
+				error: `Failed to leave meeting: ${message}`,
+			});
+		}
+	},
+);
+
 // ============================================================================
 // Meeting Endpoints
 // ============================================================================
 
 /**
  * GET /watcher/meetings
- * Get all meetings with motion summaries
+ * Get meetings with motion summaries (filtered by watcher pool membership)
  */
 watcherRouter.get(
 	"/meetings",
 	async (req: Request, res: Response): Promise<void> => {
+		if (req.user === undefined) {
+			res.status(HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED).json({
+				success: false,
+				error: "Authentication required",
+			});
+			return;
+		}
+
 		try {
 			const page = parseInt(
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Query param is string
@@ -51,7 +257,11 @@ watcherRouter.get(
 				DECIMAL_RADIX,
 			);
 
-			const { meetings, total } = await getWatcherMeetings(page, limit);
+			const { meetings, total } = await getWatcherMeetings(
+				req.user.id,
+				page,
+				limit,
+			);
 
 			res.json({
 				data: meetings,

--- a/packages/server/src/scripts/migrate.ts
+++ b/packages/server/src/scripts/migrate.ts
@@ -1,6 +1,7 @@
 /**
  * Migration script entry point
  */
+import "dotenv/config";
 import pino from "pino";
 import { runMigrations } from "../database/migrate.js";
 

--- a/packages/server/src/services/auth-service.ts
+++ b/packages/server/src/services/auth-service.ts
@@ -15,6 +15,31 @@ const EMPTY_ARRAY_LENGTH = 0;
 const DEFAULT_JWT_EXPIRES_IN = "24h";
 
 /**
+ * Check if user is a meeting admin for any active meeting
+ * Returns true if user is in the admin_pool of any currently active meeting
+ */
+async function isUserMeetingAdminForAnyMeeting(
+	userId: string,
+): Promise<boolean> {
+	const result = await db.query<{ exists: boolean }>(
+		`SELECT EXISTS(
+			SELECT 1 FROM user_pools up
+			INNER JOIN meetings m ON m.admin_pool_id = up.pool_id
+			WHERE up.user_id = :userId
+			  AND NOW() >= m.start_date
+			  AND NOW() <= m.end_date
+		) as exists`,
+		{ userId },
+	);
+
+	// SELECT EXISTS always returns exactly one row
+	const {
+		rows: [row],
+	} = result;
+	return row.exists;
+}
+
+/**
  * Internal user type with password hash (never exposed via API)
  */
 interface UserWithPassword {
@@ -123,6 +148,9 @@ export async function validateLogin(
 		return { success: false, errorCode: LoginErrorCode.AccountDisabled };
 	}
 
+	// Check if user is a meeting admin for any active meeting
+	const isMeetingAdmin = await isUserMeetingAdminForAnyMeeting(user.id);
+
 	// Success - return auth user (without sensitive data)
 	return {
 		success: true,
@@ -133,6 +161,7 @@ export async function validateLogin(
 			lastName: user.lastName,
 			isAdmin: user.isAdmin,
 			isWatcher: user.isWatcher,
+			isMeetingAdmin,
 		},
 	};
 }
@@ -239,6 +268,10 @@ export async function getAuthUserById(
 	const {
 		rows: [row],
 	} = result;
+
+	// Check if user is a meeting admin for any active meeting
+	const isMeetingAdmin = await isUserMeetingAdminForAnyMeeting(row.id);
+
 	return {
 		id: row.id,
 		username: row.username,
@@ -246,5 +279,6 @@ export async function getAuthUserById(
 		lastName: row.last_name,
 		isAdmin: row.is_admin,
 		isWatcher: row.is_watcher,
+		isMeetingAdmin,
 	};
 }

--- a/packages/server/src/services/meeting-participant-service.ts
+++ b/packages/server/src/services/meeting-participant-service.ts
@@ -9,7 +9,7 @@ import {
 	type MeetingParticipant,
 	type MeetingWithPool,
 } from "@mcdc-convention-voting/shared";
-import { db } from "../database/db.js";
+import { db, withTransaction } from "../database/db.js";
 
 // Array index constants
 const FIRST_ROW = 0;
@@ -184,46 +184,16 @@ export async function getJoinableMeetingsForVoter(
 }
 
 /**
- * Check if user has already been counted for quorum in a meeting
- */
-async function hasBeenCountedForQuorum(
-	userId: string,
-	meetingId: number,
-): Promise<boolean> {
-	const result = await db.query<{ quorum_counted_at: Date | null }>(
-		`SELECT quorum_counted_at FROM meeting_participants
-		 WHERE user_id = :userId
-		   AND meeting_id = :meetingId
-		   AND role = 'voter'
-		   AND quorum_counted_at IS NOT NULL
-		 LIMIT 1`,
-		{ userId, meetingId },
-	);
-
-	return result.rows.length > EMPTY_ARRAY_LENGTH;
-}
-
-/**
- * Check if quorum has been called for a meeting
- */
-async function isQuorumCalled(meetingId: number): Promise<boolean> {
-	const result = await db.query<{ quorum_called_at: Date | null }>(
-		`SELECT quorum_called_at FROM meetings WHERE id = :meetingId`,
-		{ meetingId },
-	);
-
-	if (result.rows.length === EMPTY_ARRAY_LENGTH) {
-		return false;
-	}
-
-	return result.rows[FIRST_ROW].quorum_called_at !== null;
-}
-
-/**
- * Join a meeting as a voter
- * - Leaves any current meeting first
- * - Creates new participation record
- * - Counts toward quorum if quorum is open and user hasn't been counted before
+ * Join a meeting as a voter.
+ *
+ * Validation (meeting is active, user is in the quorum pool) runs outside the
+ * transaction. The UPDATE that leaves any current meeting and the INSERT of
+ * the new participation row run atomically inside a single transaction, so a
+ * failed INSERT rolls the leave back.
+ *
+ * Quorum counting is decided by the INSERT itself via a CASE/EXISTS expression,
+ * so there is no window where `callQuorum` could interleave between a "should
+ * count" check and the write — the decision is made in the same statement.
  */
 export async function joinMeetingAsVoter(
 	userId: string,
@@ -276,26 +246,43 @@ export async function joinMeetingAsVoter(
 		throw new Error("User is not eligible to join this meeting as a voter");
 	}
 
-	// Leave current meeting if any
-	await leaveCurrentMeeting(userId);
+	const insertedRow = await withTransaction(async (tx) => {
+		await tx.query(
+			`UPDATE meeting_participants
+			 SET left_at = NOW(), updated_at = NOW()
+			 WHERE user_id = :userId AND left_at IS NULL`,
+			{ userId },
+		);
 
-	// Determine if we should count toward quorum
-	// Only count if quorum hasn't been called and user hasn't been counted before
-	const quorumCalled = await isQuorumCalled(meetingId);
-	const alreadyCounted = await hasBeenCountedForQuorum(userId, meetingId);
-	const shouldCountQuorum = !quorumCalled && !alreadyCounted;
+		const insertResult = await tx.query<MeetingParticipantRow>(
+			`INSERT INTO meeting_participants (user_id, meeting_id, role, quorum_counted_at)
+			 VALUES (
+			   :userId,
+			   :meetingId,
+			   'voter',
+			   CASE
+			     WHEN EXISTS (
+			       SELECT 1 FROM meetings
+			       WHERE id = :meetingId AND quorum_called_at IS NULL
+			     )
+			     AND NOT EXISTS (
+			       SELECT 1 FROM meeting_participants
+			       WHERE user_id = :userId
+			         AND meeting_id = :meetingId
+			         AND role = 'voter'
+			         AND quorum_counted_at IS NOT NULL
+			     )
+			     THEN NOW()
+			     ELSE NULL
+			   END
+			 )
+			 RETURNING *`,
+			{ userId, meetingId },
+		);
 
-	// Create participation record
-	const insertResult = await db.query<MeetingParticipantRow>(
-		`INSERT INTO meeting_participants (user_id, meeting_id, role, quorum_counted_at)
-		 VALUES (:userId, :meetingId, 'voter', ${shouldCountQuorum ? "NOW()" : "NULL"})
-		 RETURNING *`,
-		{ userId, meetingId },
-	);
+		return insertResult.rows[FIRST_ROW];
+	});
 
-	const {
-		rows: [insertedRow],
-	} = insertResult;
 	const participant = rowToMeetingParticipant(insertedRow);
 
 	const {
@@ -512,20 +499,24 @@ export async function joinMeetingAsWatcher(
 		throw new Error("User is not eligible to join this meeting as a watcher");
 	}
 
-	// Leave current meeting if any
-	await leaveCurrentMeeting(userId);
+	// Leave any current meeting and insert the new watcher participation in a
+	// single transaction so a failed INSERT rolls the leave back.
+	const insertedRow = await withTransaction(async (tx) => {
+		await tx.query(
+			`UPDATE meeting_participants
+			 SET left_at = NOW(), updated_at = NOW()
+			 WHERE user_id = :userId AND left_at IS NULL`,
+			{ userId },
+		);
+		const insertResult = await tx.query<MeetingParticipantRow>(
+			`INSERT INTO meeting_participants (user_id, meeting_id, role)
+			 VALUES (:userId, :meetingId, 'watcher')
+			 RETURNING *`,
+			{ userId, meetingId },
+		);
+		return insertResult.rows[FIRST_ROW];
+	});
 
-	// Create participation record (no quorum counting for watchers)
-	const insertResult = await db.query<MeetingParticipantRow>(
-		`INSERT INTO meeting_participants (user_id, meeting_id, role)
-		 VALUES (:userId, :meetingId, 'watcher')
-		 RETURNING *`,
-		{ userId, meetingId },
-	);
-
-	const {
-		rows: [insertedRow],
-	} = insertResult;
 	const participant = rowToMeetingParticipant(insertedRow);
 
 	const {
@@ -709,20 +700,24 @@ export async function joinMeetingAsAdmin(
 		}
 	}
 
-	// Leave current meeting if any
-	await leaveCurrentMeeting(userId);
+	// Leave any current meeting and insert the new admin participation in a
+	// single transaction so a failed INSERT rolls the leave back.
+	const insertedRow = await withTransaction(async (tx) => {
+		await tx.query(
+			`UPDATE meeting_participants
+			 SET left_at = NOW(), updated_at = NOW()
+			 WHERE user_id = :userId AND left_at IS NULL`,
+			{ userId },
+		);
+		const insertResult = await tx.query<MeetingParticipantRow>(
+			`INSERT INTO meeting_participants (user_id, meeting_id, role)
+			 VALUES (:userId, :meetingId, 'meeting_admin')
+			 RETURNING *`,
+			{ userId, meetingId },
+		);
+		return insertResult.rows[FIRST_ROW];
+	});
 
-	// Create participation record (no quorum counting for admins)
-	const insertResult = await db.query<MeetingParticipantRow>(
-		`INSERT INTO meeting_participants (user_id, meeting_id, role)
-		 VALUES (:userId, :meetingId, 'meeting_admin')
-		 RETURNING *`,
-		{ userId, meetingId },
-	);
-
-	const {
-		rows: [insertedRow],
-	} = insertResult;
 	const participant = rowToMeetingParticipant(insertedRow);
 
 	const {

--- a/packages/server/src/services/meeting-participant-service.ts
+++ b/packages/server/src/services/meeting-participant-service.ts
@@ -1,0 +1,767 @@
+/**
+ * Meeting Participant service
+ * Handles user participation in meetings (joining, leaving, quorum tracking)
+ */
+import {
+	ParticipantRole,
+	type CurrentMeetingInfo,
+	type JoinableMeeting,
+	type MeetingParticipant,
+	type MeetingWithPool,
+} from "@mcdc-convention-voting/shared";
+import { db } from "../database/db.js";
+
+// Array index constants
+const FIRST_ROW = 0;
+const EMPTY_ARRAY_LENGTH = 0;
+
+/**
+ * Database row type for meeting_participants table
+ */
+interface MeetingParticipantRow {
+	id: number;
+	user_id: string;
+	meeting_id: number;
+	role: string;
+	joined_at: Date;
+	left_at: Date | null;
+	quorum_counted_at: Date | null;
+	created_at: Date;
+	updated_at: Date;
+}
+
+/**
+ * Convert database row to MeetingParticipant
+ */
+function rowToMeetingParticipant(
+	row: MeetingParticipantRow,
+): MeetingParticipant {
+	return {
+		id: row.id,
+		userId: row.user_id,
+		meetingId: row.meeting_id,
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Database enum returns as string
+		role: row.role as ParticipantRole,
+		joinedAt: row.joined_at,
+		leftAt: row.left_at,
+		quorumCountedAt: row.quorum_counted_at,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+	};
+}
+
+/**
+ * Get the user's current active meeting participation (left_at IS NULL)
+ */
+export async function getCurrentParticipation(
+	userId: string,
+): Promise<MeetingParticipant | null> {
+	const result = await db.query<MeetingParticipantRow>(
+		`SELECT * FROM meeting_participants
+		 WHERE user_id = :userId AND left_at IS NULL
+		 ORDER BY joined_at DESC
+		 LIMIT 1`,
+		{ userId },
+	);
+
+	if (result.rows.length === EMPTY_ARRAY_LENGTH) {
+		return null;
+	}
+
+	return rowToMeetingParticipant(result.rows[FIRST_ROW]);
+}
+
+/**
+ * Get current meeting info for a user
+ * Returns meeting details along with participation record
+ */
+export async function getCurrentMeetingInfo(
+	userId: string,
+): Promise<CurrentMeetingInfo | null> {
+	const participation = await getCurrentParticipation(userId);
+
+	if (participation === null) {
+		return null;
+	}
+
+	// Get meeting details with pool names
+	const meetingResult = await db.query<{
+		id: number;
+		name: string;
+		description: string | null;
+		start_date: Date;
+		end_date: Date;
+		quorum_voting_pool_id: number;
+		watcher_pool_id: number | null;
+		admin_pool_id: number | null;
+		quorum_called_at: Date | null;
+		created_at: Date;
+		updated_at: Date;
+		quorum_pool_name: string;
+		watcher_pool_name: string | null;
+		admin_pool_name: string | null;
+	}>(
+		`SELECT m.*,
+		        qp.pool_name as quorum_pool_name,
+		        wp.pool_name as watcher_pool_name,
+		        ap.pool_name as admin_pool_name
+		 FROM meetings m
+		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
+		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
+		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
+		 WHERE m.id = :meetingId`,
+		{ meetingId: participation.meetingId },
+	);
+
+	if (meetingResult.rows.length === EMPTY_ARRAY_LENGTH) {
+		return null;
+	}
+
+	const {
+		rows: [row],
+	} = meetingResult;
+	const meeting: MeetingWithPool = {
+		id: row.id,
+		name: row.name,
+		description: row.description,
+		startDate: row.start_date,
+		endDate: row.end_date,
+		quorumVotingPoolId: row.quorum_voting_pool_id,
+		watcherPoolId: row.watcher_pool_id,
+		adminPoolId: row.admin_pool_id,
+		quorumCalledAt: row.quorum_called_at,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+		quorumVotingPoolName: row.quorum_pool_name,
+		watcherPoolName: row.watcher_pool_name,
+		adminPoolName: row.admin_pool_name,
+	};
+
+	return {
+		meeting,
+		participant: participation,
+	};
+}
+
+/**
+ * Get active meetings that a user can join as a voter
+ * Returns meetings where:
+ * - Meeting is currently active (now between start_date and end_date)
+ * - User is in the meeting's quorum_voting_pool
+ * - User is not already in any meeting
+ */
+export async function getJoinableMeetingsForVoter(
+	userId: string,
+): Promise<JoinableMeeting[]> {
+	const result = await db.query<{
+		id: number;
+		name: string;
+		description: string | null;
+		start_date: Date;
+		end_date: Date;
+		pool_name: string;
+	}>(
+		`SELECT DISTINCT m.id, m.name, m.description, m.start_date, m.end_date, p.pool_name
+		 FROM meetings m
+		 INNER JOIN pools p ON m.quorum_voting_pool_id = p.id
+		 INNER JOIN user_pools up ON up.pool_id = m.quorum_voting_pool_id
+		 WHERE up.user_id = :userId
+		   AND NOW() >= m.start_date
+		   AND NOW() <= m.end_date
+		 ORDER BY m.start_date ASC`,
+		{ userId },
+	);
+
+	return result.rows.map((row) => ({
+		id: row.id,
+		name: row.name,
+		description: row.description,
+		startDate: row.start_date,
+		endDate: row.end_date,
+		quorumVotingPoolName: row.pool_name,
+		role: ParticipantRole.Voter,
+	}));
+}
+
+/**
+ * Check if user has already been counted for quorum in a meeting
+ */
+async function hasBeenCountedForQuorum(
+	userId: string,
+	meetingId: number,
+): Promise<boolean> {
+	const result = await db.query<{ quorum_counted_at: Date | null }>(
+		`SELECT quorum_counted_at FROM meeting_participants
+		 WHERE user_id = :userId
+		   AND meeting_id = :meetingId
+		   AND role = 'voter'
+		   AND quorum_counted_at IS NOT NULL
+		 LIMIT 1`,
+		{ userId, meetingId },
+	);
+
+	return result.rows.length > EMPTY_ARRAY_LENGTH;
+}
+
+/**
+ * Check if quorum has been called for a meeting
+ */
+async function isQuorumCalled(meetingId: number): Promise<boolean> {
+	const result = await db.query<{ quorum_called_at: Date | null }>(
+		`SELECT quorum_called_at FROM meetings WHERE id = :meetingId`,
+		{ meetingId },
+	);
+
+	if (result.rows.length === EMPTY_ARRAY_LENGTH) {
+		return false;
+	}
+
+	return result.rows[FIRST_ROW].quorum_called_at !== null;
+}
+
+/**
+ * Join a meeting as a voter
+ * - Leaves any current meeting first
+ * - Creates new participation record
+ * - Counts toward quorum if quorum is open and user hasn't been counted before
+ */
+export async function joinMeetingAsVoter(
+	userId: string,
+	meetingId: number,
+): Promise<{ participant: MeetingParticipant; meeting: MeetingWithPool }> {
+	// Verify meeting exists and is active
+	const meetingResult = await db.query<{
+		id: number;
+		name: string;
+		description: string | null;
+		start_date: Date;
+		end_date: Date;
+		quorum_voting_pool_id: number;
+		watcher_pool_id: number | null;
+		admin_pool_id: number | null;
+		quorum_called_at: Date | null;
+		created_at: Date;
+		updated_at: Date;
+		quorum_pool_name: string;
+		watcher_pool_name: string | null;
+		admin_pool_name: string | null;
+	}>(
+		`SELECT m.*,
+		        qp.pool_name as quorum_pool_name,
+		        wp.pool_name as watcher_pool_name,
+		        ap.pool_name as admin_pool_name
+		 FROM meetings m
+		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
+		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
+		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
+		 WHERE m.id = :meetingId
+		   AND NOW() >= m.start_date
+		   AND NOW() <= m.end_date`,
+		{ meetingId },
+	);
+
+	if (meetingResult.rows.length === EMPTY_ARRAY_LENGTH) {
+		throw new Error("Meeting not found or not currently active");
+	}
+
+	// Verify user is in the quorum pool
+	const poolCheck = await db.query<{ user_id: string }>(
+		`SELECT up.user_id FROM user_pools up
+		 INNER JOIN meetings m ON m.quorum_voting_pool_id = up.pool_id
+		 WHERE m.id = :meetingId AND up.user_id = :userId`,
+		{ meetingId, userId },
+	);
+
+	if (poolCheck.rows.length === EMPTY_ARRAY_LENGTH) {
+		throw new Error("User is not eligible to join this meeting as a voter");
+	}
+
+	// Leave current meeting if any
+	await leaveCurrentMeeting(userId);
+
+	// Determine if we should count toward quorum
+	// Only count if quorum hasn't been called and user hasn't been counted before
+	const quorumCalled = await isQuorumCalled(meetingId);
+	const alreadyCounted = await hasBeenCountedForQuorum(userId, meetingId);
+	const shouldCountQuorum = !quorumCalled && !alreadyCounted;
+
+	// Create participation record
+	const insertResult = await db.query<MeetingParticipantRow>(
+		`INSERT INTO meeting_participants (user_id, meeting_id, role, quorum_counted_at)
+		 VALUES (:userId, :meetingId, 'voter', ${shouldCountQuorum ? "NOW()" : "NULL"})
+		 RETURNING *`,
+		{ userId, meetingId },
+	);
+
+	const {
+		rows: [insertedRow],
+	} = insertResult;
+	const participant = rowToMeetingParticipant(insertedRow);
+
+	const {
+		rows: [meetingRow],
+	} = meetingResult;
+	const meeting: MeetingWithPool = {
+		id: meetingRow.id,
+		name: meetingRow.name,
+		description: meetingRow.description,
+		startDate: meetingRow.start_date,
+		endDate: meetingRow.end_date,
+		quorumVotingPoolId: meetingRow.quorum_voting_pool_id,
+		watcherPoolId: meetingRow.watcher_pool_id,
+		adminPoolId: meetingRow.admin_pool_id,
+		quorumCalledAt: meetingRow.quorum_called_at,
+		createdAt: meetingRow.created_at,
+		updatedAt: meetingRow.updated_at,
+		quorumVotingPoolName: meetingRow.quorum_pool_name,
+		watcherPoolName: meetingRow.watcher_pool_name,
+		adminPoolName: meetingRow.admin_pool_name,
+	};
+
+	return { participant, meeting };
+}
+
+/**
+ * Leave the user's current meeting
+ * Sets left_at timestamp on active participation record
+ */
+export async function leaveCurrentMeeting(userId: string): Promise<boolean> {
+	const result = await db.query(
+		`UPDATE meeting_participants
+		 SET left_at = NOW(), updated_at = NOW()
+		 WHERE user_id = :userId AND left_at IS NULL
+		 RETURNING id`,
+		{ userId },
+	);
+
+	return result.rows.length > EMPTY_ARRAY_LENGTH;
+}
+
+/**
+ * Get count of voters who have been counted for quorum in a meeting
+ */
+export async function getQuorumParticipantCount(
+	meetingId: number,
+): Promise<number> {
+	const result = await db.query<{ count: string }>(
+		`SELECT COUNT(*) as count FROM meeting_participants
+		 WHERE meeting_id = :meetingId
+		   AND role = 'voter'
+		   AND quorum_counted_at IS NOT NULL`,
+		{ meetingId },
+	);
+
+	const DECIMAL_RADIX = 10;
+	return parseInt(result.rows[FIRST_ROW].count, DECIMAL_RADIX);
+}
+
+/**
+ * Get list of voters counted for quorum in a meeting
+ */
+export async function getQuorumParticipants(meetingId: number): Promise<
+	Array<{
+		userId: string;
+		username: string;
+		firstName: string;
+		lastName: string;
+		countedAt: Date;
+	}>
+> {
+	const result = await db.query<{
+		user_id: string;
+		username: string;
+		first_name: string;
+		last_name: string;
+		quorum_counted_at: Date;
+	}>(
+		`SELECT mp.user_id, u.username, u.first_name, u.last_name, mp.quorum_counted_at
+		 FROM meeting_participants mp
+		 INNER JOIN users u ON mp.user_id = u.id
+		 WHERE mp.meeting_id = :meetingId
+		   AND mp.role = 'voter'
+		   AND mp.quorum_counted_at IS NOT NULL
+		 ORDER BY mp.quorum_counted_at ASC`,
+		{ meetingId },
+	);
+
+	return result.rows.map((row) => ({
+		userId: row.user_id,
+		username: row.username,
+		firstName: row.first_name,
+		lastName: row.last_name,
+		countedAt: row.quorum_counted_at,
+	}));
+}
+
+/**
+ * Get count of currently active participants in a meeting
+ */
+export async function getActiveParticipantCount(
+	meetingId: number,
+): Promise<number> {
+	const result = await db.query<{ count: string }>(
+		`SELECT COUNT(*) as count FROM meeting_participants
+		 WHERE meeting_id = :meetingId AND left_at IS NULL`,
+		{ meetingId },
+	);
+
+	const DECIMAL_RADIX = 10;
+	return parseInt(result.rows[FIRST_ROW].count, DECIMAL_RADIX);
+}
+
+// ============================================================================
+// Watcher Meeting Functions
+// ============================================================================
+
+/**
+ * Get active meetings that a user can join as a watcher
+ * Returns meetings where:
+ * - Meeting is currently active (now between start_date and end_date)
+ * - User is in the meeting's watcher_pool
+ */
+export async function getJoinableMeetingsForWatcher(
+	userId: string,
+): Promise<JoinableMeeting[]> {
+	const result = await db.query<{
+		id: number;
+		name: string;
+		description: string | null;
+		start_date: Date;
+		end_date: Date;
+		pool_name: string;
+	}>(
+		`SELECT DISTINCT m.id, m.name, m.description, m.start_date, m.end_date, p.pool_name
+		 FROM meetings m
+		 INNER JOIN pools p ON m.watcher_pool_id = p.id
+		 INNER JOIN user_pools up ON up.pool_id = m.watcher_pool_id
+		 WHERE up.user_id = :userId
+		   AND NOW() >= m.start_date
+		   AND NOW() <= m.end_date
+		   AND m.watcher_pool_id IS NOT NULL
+		 ORDER BY m.start_date ASC`,
+		{ userId },
+	);
+
+	return result.rows.map((row) => ({
+		id: row.id,
+		name: row.name,
+		description: row.description,
+		startDate: row.start_date,
+		endDate: row.end_date,
+		quorumVotingPoolName: row.pool_name,
+		role: ParticipantRole.Watcher,
+	}));
+}
+
+/**
+ * Join a meeting as a watcher
+ * - Leaves any current meeting first
+ * - Creates new participation record (no quorum counting for watchers)
+ */
+export async function joinMeetingAsWatcher(
+	userId: string,
+	meetingId: number,
+): Promise<{ participant: MeetingParticipant; meeting: MeetingWithPool }> {
+	// Verify meeting exists, is active, and has a watcher pool
+	const meetingResult = await db.query<{
+		id: number;
+		name: string;
+		description: string | null;
+		start_date: Date;
+		end_date: Date;
+		quorum_voting_pool_id: number;
+		watcher_pool_id: number | null;
+		admin_pool_id: number | null;
+		quorum_called_at: Date | null;
+		created_at: Date;
+		updated_at: Date;
+		quorum_pool_name: string;
+		watcher_pool_name: string | null;
+		admin_pool_name: string | null;
+	}>(
+		`SELECT m.*,
+		        qp.pool_name as quorum_pool_name,
+		        wp.pool_name as watcher_pool_name,
+		        ap.pool_name as admin_pool_name
+		 FROM meetings m
+		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
+		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
+		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
+		 WHERE m.id = :meetingId
+		   AND NOW() >= m.start_date
+		   AND NOW() <= m.end_date
+		   AND m.watcher_pool_id IS NOT NULL`,
+		{ meetingId },
+	);
+
+	if (meetingResult.rows.length === EMPTY_ARRAY_LENGTH) {
+		throw new Error(
+			"Meeting not found, not currently active, or does not allow watchers",
+		);
+	}
+
+	// Verify user is in the watcher pool
+	const poolCheck = await db.query<{ user_id: string }>(
+		`SELECT up.user_id FROM user_pools up
+		 INNER JOIN meetings m ON m.watcher_pool_id = up.pool_id
+		 WHERE m.id = :meetingId AND up.user_id = :userId`,
+		{ meetingId, userId },
+	);
+
+	if (poolCheck.rows.length === EMPTY_ARRAY_LENGTH) {
+		throw new Error("User is not eligible to join this meeting as a watcher");
+	}
+
+	// Leave current meeting if any
+	await leaveCurrentMeeting(userId);
+
+	// Create participation record (no quorum counting for watchers)
+	const insertResult = await db.query<MeetingParticipantRow>(
+		`INSERT INTO meeting_participants (user_id, meeting_id, role)
+		 VALUES (:userId, :meetingId, 'watcher')
+		 RETURNING *`,
+		{ userId, meetingId },
+	);
+
+	const {
+		rows: [insertedRow],
+	} = insertResult;
+	const participant = rowToMeetingParticipant(insertedRow);
+
+	const {
+		rows: [meetingRow],
+	} = meetingResult;
+	const meeting: MeetingWithPool = {
+		id: meetingRow.id,
+		name: meetingRow.name,
+		description: meetingRow.description,
+		startDate: meetingRow.start_date,
+		endDate: meetingRow.end_date,
+		quorumVotingPoolId: meetingRow.quorum_voting_pool_id,
+		watcherPoolId: meetingRow.watcher_pool_id,
+		adminPoolId: meetingRow.admin_pool_id,
+		quorumCalledAt: meetingRow.quorum_called_at,
+		createdAt: meetingRow.created_at,
+		updatedAt: meetingRow.updated_at,
+		quorumVotingPoolName: meetingRow.quorum_pool_name,
+		watcherPoolName: meetingRow.watcher_pool_name,
+		adminPoolName: meetingRow.admin_pool_name,
+	};
+
+	return { participant, meeting };
+}
+
+// ============================================================================
+// Meeting Admin Functions
+// ============================================================================
+
+/**
+ * Get active meetings that a user can join as a meeting admin
+ * Returns meetings where:
+ * - Meeting is currently active (now between start_date and end_date)
+ * - User is in the meeting's admin_pool
+ */
+export async function getJoinableMeetingsForAdmin(
+	userId: string,
+): Promise<JoinableMeeting[]> {
+	const result = await db.query<{
+		id: number;
+		name: string;
+		description: string | null;
+		start_date: Date;
+		end_date: Date;
+		pool_name: string;
+	}>(
+		`SELECT DISTINCT m.id, m.name, m.description, m.start_date, m.end_date, p.pool_name
+		 FROM meetings m
+		 INNER JOIN pools p ON m.admin_pool_id = p.id
+		 INNER JOIN user_pools up ON up.pool_id = m.admin_pool_id
+		 WHERE up.user_id = :userId
+		   AND NOW() >= m.start_date
+		   AND NOW() <= m.end_date
+		   AND m.admin_pool_id IS NOT NULL
+		 ORDER BY m.start_date ASC`,
+		{ userId },
+	);
+
+	return result.rows.map((row) => ({
+		id: row.id,
+		name: row.name,
+		description: row.description,
+		startDate: row.start_date,
+		endDate: row.end_date,
+		quorumVotingPoolName: row.pool_name,
+		role: ParticipantRole.MeetingAdmin,
+	}));
+}
+
+/**
+ * Get all active meetings for global admins
+ * Returns all meetings that are currently active (now between start_date and end_date)
+ * This is used for global admins who can join any meeting
+ */
+export async function getAllActiveMeetings(): Promise<JoinableMeeting[]> {
+	const result = await db.query<{
+		id: number;
+		name: string;
+		description: string | null;
+		start_date: Date;
+		end_date: Date;
+		pool_name: string;
+	}>(
+		`SELECT m.id, m.name, m.description, m.start_date, m.end_date, p.pool_name
+		 FROM meetings m
+		 INNER JOIN pools p ON m.quorum_voting_pool_id = p.id
+		 WHERE NOW() >= m.start_date
+		   AND NOW() <= m.end_date
+		 ORDER BY m.start_date ASC`,
+		{},
+	);
+
+	return result.rows.map((row) => ({
+		id: row.id,
+		name: row.name,
+		description: row.description,
+		startDate: row.start_date,
+		endDate: row.end_date,
+		quorumVotingPoolName: row.pool_name,
+		role: ParticipantRole.MeetingAdmin,
+	}));
+}
+
+/**
+ * Join a meeting as a meeting admin
+ * - Leaves any current meeting first
+ * - Creates new participation record (no quorum counting for admins)
+ * - Global admins can join any active meeting
+ * - Meeting admins must be in the meeting's admin pool
+ */
+export async function joinMeetingAsAdmin(
+	userId: string,
+	meetingId: number,
+	isGlobalAdmin = false,
+): Promise<{ participant: MeetingParticipant; meeting: MeetingWithPool }> {
+	// Verify meeting exists and is active
+	// Global admins can join any meeting; meeting admins need an admin pool
+	const meetingQuery = isGlobalAdmin
+		? `SELECT m.*,
+		        qp.pool_name as quorum_pool_name,
+		        wp.pool_name as watcher_pool_name,
+		        ap.pool_name as admin_pool_name
+		 FROM meetings m
+		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
+		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
+		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
+		 WHERE m.id = :meetingId
+		   AND NOW() >= m.start_date
+		   AND NOW() <= m.end_date`
+		: `SELECT m.*,
+		        qp.pool_name as quorum_pool_name,
+		        wp.pool_name as watcher_pool_name,
+		        ap.pool_name as admin_pool_name
+		 FROM meetings m
+		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
+		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
+		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
+		 WHERE m.id = :meetingId
+		   AND NOW() >= m.start_date
+		   AND NOW() <= m.end_date
+		   AND m.admin_pool_id IS NOT NULL`;
+
+	const meetingResult = await db.query<{
+		id: number;
+		name: string;
+		description: string | null;
+		start_date: Date;
+		end_date: Date;
+		quorum_voting_pool_id: number;
+		watcher_pool_id: number | null;
+		admin_pool_id: number | null;
+		quorum_called_at: Date | null;
+		created_at: Date;
+		updated_at: Date;
+		quorum_pool_name: string;
+		watcher_pool_name: string | null;
+		admin_pool_name: string | null;
+	}>(meetingQuery, { meetingId });
+
+	if (meetingResult.rows.length === EMPTY_ARRAY_LENGTH) {
+		throw new Error(
+			isGlobalAdmin
+				? "Meeting not found or not currently active"
+				: "Meeting not found, not currently active, or does not allow meeting admins",
+		);
+	}
+
+	// Verify user is in the admin pool (skip for global admins)
+	if (!isGlobalAdmin) {
+		const poolCheck = await db.query<{ user_id: string }>(
+			`SELECT up.user_id FROM user_pools up
+			 INNER JOIN meetings m ON m.admin_pool_id = up.pool_id
+			 WHERE m.id = :meetingId AND up.user_id = :userId`,
+			{ meetingId, userId },
+		);
+
+		if (poolCheck.rows.length === EMPTY_ARRAY_LENGTH) {
+			throw new Error(
+				"User is not eligible to join this meeting as a meeting admin",
+			);
+		}
+	}
+
+	// Leave current meeting if any
+	await leaveCurrentMeeting(userId);
+
+	// Create participation record (no quorum counting for admins)
+	const insertResult = await db.query<MeetingParticipantRow>(
+		`INSERT INTO meeting_participants (user_id, meeting_id, role)
+		 VALUES (:userId, :meetingId, 'meeting_admin')
+		 RETURNING *`,
+		{ userId, meetingId },
+	);
+
+	const {
+		rows: [insertedRow],
+	} = insertResult;
+	const participant = rowToMeetingParticipant(insertedRow);
+
+	const {
+		rows: [meetingRow],
+	} = meetingResult;
+	const meeting: MeetingWithPool = {
+		id: meetingRow.id,
+		name: meetingRow.name,
+		description: meetingRow.description,
+		startDate: meetingRow.start_date,
+		endDate: meetingRow.end_date,
+		quorumVotingPoolId: meetingRow.quorum_voting_pool_id,
+		watcherPoolId: meetingRow.watcher_pool_id,
+		adminPoolId: meetingRow.admin_pool_id,
+		quorumCalledAt: meetingRow.quorum_called_at,
+		createdAt: meetingRow.created_at,
+		updatedAt: meetingRow.updated_at,
+		quorumVotingPoolName: meetingRow.quorum_pool_name,
+		watcherPoolName: meetingRow.watcher_pool_name,
+		adminPoolName: meetingRow.admin_pool_name,
+	};
+
+	return { participant, meeting };
+}
+
+/**
+ * Check if a user is a meeting admin for a specific meeting
+ * Returns true if user is in the meeting's admin pool
+ */
+export async function isUserMeetingAdmin(
+	userId: string,
+	meetingId: number,
+): Promise<boolean> {
+	const result = await db.query<{ user_id: string }>(
+		`SELECT up.user_id FROM user_pools up
+		 INNER JOIN meetings m ON m.admin_pool_id = up.pool_id
+		 WHERE m.id = :meetingId AND up.user_id = :userId`,
+		{ meetingId, userId },
+	);
+
+	return result.rows.length > EMPTY_ARRAY_LENGTH;
+}

--- a/packages/server/src/services/meeting-service.ts
+++ b/packages/server/src/services/meeting-service.ts
@@ -480,6 +480,43 @@ export async function deleteMeeting(meetingId: number): Promise<void> {
 	}
 }
 
+/**
+ * Look up the meeting ID that a motion belongs to.
+ * Returns null if the motion does not exist.
+ */
+export async function getMeetingIdForMotion(
+	motionId: number,
+): Promise<number | null> {
+	const result = await db.query<{ meeting_id: number }>(
+		"SELECT meeting_id FROM motions WHERE id = :motionId",
+		{ motionId },
+	);
+	if (result.rows.length === EMPTY_ARRAY_LENGTH) {
+		return null;
+	}
+	return result.rows[FIRST_ROW].meeting_id;
+}
+
+/**
+ * Look up the meeting ID that a choice belongs to (via its motion).
+ * Returns null if the choice does not exist.
+ */
+export async function getMeetingIdForChoice(
+	choiceId: number,
+): Promise<number | null> {
+	const result = await db.query<{ meeting_id: number }>(
+		`SELECT m.meeting_id
+		 FROM choices c
+		 INNER JOIN motions m ON c.motion_id = m.id
+		 WHERE c.id = :choiceId`,
+		{ choiceId },
+	);
+	if (result.rows.length === EMPTY_ARRAY_LENGTH) {
+		return null;
+	}
+	return result.rows[FIRST_ROW].meeting_id;
+}
+
 // ============================================================================
 // Motion Functions
 // ============================================================================

--- a/packages/server/src/services/meeting-service.ts
+++ b/packages/server/src/services/meeting-service.ts
@@ -50,6 +50,26 @@ const VALID_STATUS_TRANSITIONS: Record<MotionStatus, MotionStatus[]> = {
 };
 
 // ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Verify a pool exists, throw error if not
+ */
+async function verifyPoolExists(
+	poolId: number,
+	poolType: string,
+): Promise<void> {
+	const poolCheck = await db.query<{ id: number }>(
+		"SELECT id FROM pools WHERE id = :poolId",
+		{ poolId },
+	);
+	if (poolCheck.rows.length === EMPTY_ARRAY_LENGTH) {
+		throw new Error(`${poolType} with ID ${String(poolId)} does not exist`);
+	}
+}
+
+// ============================================================================
 // Meeting Functions
 // ============================================================================
 
@@ -59,17 +79,27 @@ const VALID_STATUS_TRANSITIONS: Record<MotionStatus, MotionStatus[]> = {
 export async function createMeeting(
 	request: CreateMeetingRequest,
 ): Promise<Meeting> {
-	const { name, description, startDate, endDate, quorumVotingPoolId } = request;
+	const {
+		name,
+		description,
+		startDate,
+		endDate,
+		quorumVotingPoolId,
+		watcherPoolId,
+		adminPoolId,
+	} = request;
 
-	// Verify pool exists
-	const poolCheck = await db.query<{ id: number }>(
-		"SELECT id FROM pools WHERE id = :poolId",
-		{ poolId: quorumVotingPoolId },
-	);
-	if (poolCheck.rows.length === EMPTY_ARRAY_LENGTH) {
-		throw new Error(
-			`Pool with ID ${String(quorumVotingPoolId)} does not exist`,
-		);
+	// Verify quorum pool exists
+	await verifyPoolExists(quorumVotingPoolId, "Pool");
+
+	// Verify watcher pool exists if specified
+	if (watcherPoolId !== undefined && watcherPoolId !== null) {
+		await verifyPoolExists(watcherPoolId, "Watcher pool");
+	}
+
+	// Verify admin pool exists if specified
+	if (adminPoolId !== undefined && adminPoolId !== null) {
+		await verifyPoolExists(adminPoolId, "Admin pool");
 	}
 
 	const result = await db.query<{
@@ -79,12 +109,14 @@ export async function createMeeting(
 		start_date: Date;
 		end_date: Date;
 		quorum_voting_pool_id: number;
+		watcher_pool_id: number | null;
+		admin_pool_id: number | null;
 		quorum_called_at: Date | null;
 		created_at: Date;
 		updated_at: Date;
 	}>(
-		`INSERT INTO meetings (name, description, start_date, end_date, quorum_voting_pool_id)
-		 VALUES (:name, :description, :startDate, :endDate, :quorumVotingPoolId)
+		`INSERT INTO meetings (name, description, start_date, end_date, quorum_voting_pool_id, watcher_pool_id, admin_pool_id)
+		 VALUES (:name, :description, :startDate, :endDate, :quorumVotingPoolId, :watcherPoolId, :adminPoolId)
 		 RETURNING *`,
 		{
 			name,
@@ -92,6 +124,8 @@ export async function createMeeting(
 			startDate,
 			endDate,
 			quorumVotingPoolId,
+			watcherPoolId: watcherPoolId ?? null,
+			adminPoolId: adminPoolId ?? null,
 		},
 	);
 
@@ -105,6 +139,8 @@ export async function createMeeting(
 		startDate: row.start_date,
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
+		watcherPoolId: row.watcher_pool_id,
+		adminPoolId: row.admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
@@ -112,7 +148,7 @@ export async function createMeeting(
 }
 
 /**
- * Get meeting by ID with pool name
+ * Get meeting by ID with pool names
  */
 export async function getMeetingById(
 	meetingId: number,
@@ -124,14 +160,23 @@ export async function getMeetingById(
 		start_date: Date;
 		end_date: Date;
 		quorum_voting_pool_id: number;
+		watcher_pool_id: number | null;
+		admin_pool_id: number | null;
 		quorum_called_at: Date | null;
 		created_at: Date;
 		updated_at: Date;
-		pool_name: string;
+		quorum_pool_name: string;
+		watcher_pool_name: string | null;
+		admin_pool_name: string | null;
 	}>(
-		`SELECT m.*, p.pool_name
+		`SELECT m.*,
+		        qp.pool_name as quorum_pool_name,
+		        wp.pool_name as watcher_pool_name,
+		        ap.pool_name as admin_pool_name
 		 FROM meetings m
-		 INNER JOIN pools p ON m.quorum_voting_pool_id = p.id
+		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
+		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
+		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
 		 WHERE m.id = :meetingId`,
 		{ meetingId },
 	);
@@ -150,10 +195,14 @@ export async function getMeetingById(
 		startDate: row.start_date,
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
+		watcherPoolId: row.watcher_pool_id,
+		adminPoolId: row.admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
-		quorumVotingPoolName: row.pool_name,
+		quorumVotingPoolName: row.quorum_pool_name,
+		watcherPoolName: row.watcher_pool_name,
+		adminPoolName: row.admin_pool_name,
 	};
 }
 
@@ -180,14 +229,23 @@ export async function listMeetings(
 		start_date: Date;
 		end_date: Date;
 		quorum_voting_pool_id: number;
+		watcher_pool_id: number | null;
+		admin_pool_id: number | null;
 		quorum_called_at: Date | null;
 		created_at: Date;
 		updated_at: Date;
-		pool_name: string;
+		quorum_pool_name: string;
+		watcher_pool_name: string | null;
+		admin_pool_name: string | null;
 	}>(
-		`SELECT m.*, p.pool_name
+		`SELECT m.*,
+		        qp.pool_name as quorum_pool_name,
+		        wp.pool_name as watcher_pool_name,
+		        ap.pool_name as admin_pool_name
 		 FROM meetings m
-		 INNER JOIN pools p ON m.quorum_voting_pool_id = p.id
+		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
+		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
+		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
 		 ORDER BY m.start_date DESC
 		 LIMIT :limit OFFSET :offset`,
 		{ limit, offset },
@@ -200,27 +258,109 @@ export async function listMeetings(
 		startDate: row.start_date,
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
+		watcherPoolId: row.watcher_pool_id,
+		adminPoolId: row.admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
-		quorumVotingPoolName: row.pool_name,
+		quorumVotingPoolName: row.quorum_pool_name,
+		watcherPoolName: row.watcher_pool_name,
+		adminPoolName: row.admin_pool_name,
 	}));
 
 	return { meetings, total };
 }
 
 /**
- * Update meeting details
+ * List meetings for a meeting admin (filtered by admin pool membership)
+ * Only returns meetings where the user is in the admin pool
  */
-export async function updateMeeting(
-	meetingId: number,
-	updates: UpdateMeetingRequest,
-): Promise<Meeting> {
-	const { name, description, startDate, endDate, quorumVotingPoolId } = updates;
+export async function listMeetingsForMeetingAdmin(
+	userId: string,
+	page = DEFAULT_PAGE,
+	limit = DEFAULT_LIMIT,
+): Promise<{ meetings: MeetingWithPool[]; total: number }> {
+	const offset = (page - PAGE_OFFSET_ADJUSTMENT) * limit;
 
-	// Build dynamic update query
+	// Get total count for meetings where user is in admin pool
+	const countResult = await db.query<{ count: string }>(
+		`SELECT COUNT(*) as count FROM meetings m
+		 INNER JOIN user_pools up ON m.admin_pool_id = up.pool_id
+		 WHERE up.user_id = :userId`,
+		{ userId },
+	);
+	const total = parseInt(countResult.rows[FIRST_ROW].count, DECIMAL_RADIX);
+
+	// Get paginated meetings with pool names, filtered by admin pool membership
+	const result = await db.query<{
+		id: number;
+		name: string;
+		description: string | null;
+		start_date: Date;
+		end_date: Date;
+		quorum_voting_pool_id: number;
+		watcher_pool_id: number | null;
+		admin_pool_id: number | null;
+		quorum_called_at: Date | null;
+		created_at: Date;
+		updated_at: Date;
+		quorum_pool_name: string;
+		watcher_pool_name: string | null;
+		admin_pool_name: string | null;
+	}>(
+		`SELECT m.*,
+		        qp.pool_name as quorum_pool_name,
+		        wp.pool_name as watcher_pool_name,
+		        ap.pool_name as admin_pool_name
+		 FROM meetings m
+		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
+		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
+		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
+		 INNER JOIN user_pools up ON m.admin_pool_id = up.pool_id
+		 WHERE up.user_id = :userId
+		 ORDER BY m.start_date DESC
+		 LIMIT :limit OFFSET :offset`,
+		{ userId, limit, offset },
+	);
+
+	const meetings = result.rows.map((row) => ({
+		id: row.id,
+		name: row.name,
+		description: row.description,
+		startDate: row.start_date,
+		endDate: row.end_date,
+		quorumVotingPoolId: row.quorum_voting_pool_id,
+		watcherPoolId: row.watcher_pool_id,
+		adminPoolId: row.admin_pool_id,
+		quorumCalledAt: row.quorum_called_at,
+		createdAt: row.created_at,
+		updatedAt: row.updated_at,
+		quorumVotingPoolName: row.quorum_pool_name,
+		watcherPoolName: row.watcher_pool_name,
+		adminPoolName: row.admin_pool_name,
+	}));
+
+	return { meetings, total };
+}
+
+/**
+ * Build update clauses for meeting updates
+ */
+async function buildMeetingUpdateClauses(
+	updates: UpdateMeetingRequest,
+): Promise<{ setClauses: string[]; values: Record<string, unknown> }> {
+	const {
+		name,
+		description,
+		startDate,
+		endDate,
+		quorumVotingPoolId,
+		watcherPoolId,
+		adminPoolId,
+	} = updates;
+
 	const setClauses: string[] = [];
-	const values: Record<string, unknown> = { meetingId };
+	const values: Record<string, unknown> = {};
 
 	if (name !== undefined) {
 		setClauses.push(`name = :name`);
@@ -243,19 +383,39 @@ export async function updateMeeting(
 	}
 
 	if (quorumVotingPoolId !== undefined) {
-		// Verify pool exists
-		const poolCheck = await db.query<{ id: number }>(
-			"SELECT id FROM pools WHERE id = :poolId",
-			{ poolId: quorumVotingPoolId },
-		);
-		if (poolCheck.rows.length === EMPTY_ARRAY_LENGTH) {
-			throw new Error(
-				`Pool with ID ${String(quorumVotingPoolId)} does not exist`,
-			);
-		}
+		await verifyPoolExists(quorumVotingPoolId, "Pool");
 		setClauses.push(`quorum_voting_pool_id = :quorumVotingPoolId`);
 		values.quorumVotingPoolId = quorumVotingPoolId;
 	}
+
+	if (watcherPoolId !== undefined) {
+		if (watcherPoolId !== null) {
+			await verifyPoolExists(watcherPoolId, "Watcher pool");
+		}
+		setClauses.push(`watcher_pool_id = :watcherPoolId`);
+		values.watcherPoolId = watcherPoolId;
+	}
+
+	if (adminPoolId !== undefined) {
+		if (adminPoolId !== null) {
+			await verifyPoolExists(adminPoolId, "Admin pool");
+		}
+		setClauses.push(`admin_pool_id = :adminPoolId`);
+		values.adminPoolId = adminPoolId;
+	}
+
+	return { setClauses, values };
+}
+
+/**
+ * Update meeting details
+ */
+export async function updateMeeting(
+	meetingId: number,
+	updates: UpdateMeetingRequest,
+): Promise<Meeting> {
+	const { setClauses, values } = await buildMeetingUpdateClauses(updates);
+	values.meetingId = meetingId;
 
 	if (setClauses.length === EMPTY_ARRAY_LENGTH) {
 		throw new Error("No fields to update");
@@ -271,6 +431,8 @@ export async function updateMeeting(
 		start_date: Date;
 		end_date: Date;
 		quorum_voting_pool_id: number;
+		watcher_pool_id: number | null;
+		admin_pool_id: number | null;
 		quorum_called_at: Date | null;
 		created_at: Date;
 		updated_at: Date;
@@ -296,6 +458,8 @@ export async function updateMeeting(
 		startDate: row.start_date,
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
+		watcherPoolId: row.watcher_pool_id,
+		adminPoolId: row.admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,

--- a/packages/server/src/services/quorum-service.ts
+++ b/packages/server/src/services/quorum-service.ts
@@ -1,7 +1,9 @@
 /**
  * Quorum tracking and reporting service
  *
- * Calculates quorum statistics based on voter activity and pool membership.
+ * Calculates quorum statistics based on meeting participation and pool membership.
+ * Users are counted toward quorum when they join a meeting as a voter,
+ * before quorum has been called.
  */
 import { db } from "../database/db.js";
 import type {
@@ -22,10 +24,9 @@ const ZERO_COUNT = 0;
  * Get quorum report for a meeting
  *
  * Calculation logic:
- * - If quorum has been called: count distinct users with activity
- *   between meeting start and quorum_called_at
- * - If quorum not called: count distinct users with activity
- *   between meeting start and NOW (live count)
+ * - Counts voters who have explicitly joined the meeting and were counted for quorum
+ * - quorum_counted_at is set when a voter joins before quorum is called
+ * - Once quorum is called, new joiners are not counted toward quorum
  */
 export async function getQuorumReport(
 	meetingId: number,
@@ -57,9 +58,6 @@ export async function getQuorumReport(
 		rows: [meeting],
 	} = meetingResult;
 
-	// Calculate cutoff time
-	const cutoffTime = meeting.quorum_called_at ?? new Date();
-
 	// Get total eligible voters from quorum pool
 	const eligibleResult = await db.query<{ count: string }>(
 		`SELECT COUNT(DISTINCT user_id) as count
@@ -72,19 +70,14 @@ export async function getQuorumReport(
 		DECIMAL_RADIX,
 	);
 
-	// Get distinct active users from quorum pool with activity in timeframe
+	// Get count of voters who have been counted for quorum (quorum_counted_at IS NOT NULL)
 	const activeResult = await db.query<{ count: string }>(
-		`SELECT COUNT(DISTINCT al.user_id) as count
-		 FROM activity_logs al
-		 INNER JOIN user_pools up ON al.user_id = up.user_id
-		 WHERE up.pool_id = :poolId
-		   AND al.created_at >= :startDate
-		   AND al.created_at <= :cutoffTime`,
-		{
-			poolId: meeting.quorum_voting_pool_id,
-			startDate: meeting.start_date,
-			cutoffTime,
-		},
+		`SELECT COUNT(DISTINCT user_id) as count
+		 FROM meeting_participants
+		 WHERE meeting_id = :meetingId
+		   AND role = 'voter'
+		   AND quorum_counted_at IS NOT NULL`,
+		{ meetingId },
 	);
 	const activeVoterCount = parseInt(
 		activeResult.rows[FIRST_ROW].count,
@@ -97,6 +90,9 @@ export async function getQuorumReport(
 			? (activeVoterCount / totalEligibleVoters) * PERCENTAGE_MULTIPLIER
 			: ZERO_COUNT;
 
+	// Calculate as of time - use quorum_called_at if set, otherwise now
+	const calculatedAsOf = meeting.quorum_called_at ?? new Date();
+
 	return {
 		meetingId: meeting.id,
 		meetingName: meeting.name,
@@ -104,7 +100,7 @@ export async function getQuorumReport(
 		activeVoterCount,
 		activeVoterPercentage,
 		quorumCalledAt: meeting.quorum_called_at,
-		calculatedAsOf: cutoffTime,
+		calculatedAsOf,
 		meetingStartDate: meeting.start_date,
 		meetingEndDate: meeting.end_date,
 		quorumPoolName: meeting.pool_name,
@@ -137,18 +133,15 @@ export async function callQuorum(
 /**
  * Get list of active voters for quorum (for detailed view)
  *
- * Returns users from the quorum pool who had activity during the meeting.
+ * Returns users who have been counted for quorum (joined the meeting as a voter
+ * before quorum was called).
  */
 export async function getActiveVotersForQuorum(
 	meetingId: number,
 ): Promise<QuorumActiveVoter[]> {
-	const meeting = await db.query<{
-		quorum_voting_pool_id: number;
-		start_date: Date;
-		quorum_called_at: Date | null;
-	}>(
-		`SELECT quorum_voting_pool_id, start_date, quorum_called_at
-		 FROM meetings WHERE id = :meetingId`,
+	// Verify meeting exists
+	const meeting = await db.query<{ id: number }>(
+		`SELECT id FROM meetings WHERE id = :meetingId`,
 		{ meetingId },
 	);
 
@@ -156,38 +149,27 @@ export async function getActiveVotersForQuorum(
 		throw new Error(`Meeting with ID ${String(meetingId)} not found`);
 	}
 
-	const {
-		rows: [meetingRow],
-	} = meeting;
-	const {
-		quorum_voting_pool_id: poolId,
-		start_date: startDate,
-		quorum_called_at: quorumCalledAt,
-	} = meetingRow;
-	const cutoffTime = quorumCalledAt ?? new Date();
-
+	// Get voters who have been counted for quorum
 	const result = await db.query<{
 		user_id: string;
 		username: string;
 		first_name: string;
 		last_name: string;
-		last_activity: Date;
+		quorum_counted_at: Date;
 	}>(
 		`SELECT
 		   u.id as user_id,
 		   u.username,
 		   u.first_name,
 		   u.last_name,
-		   MAX(al.created_at) as last_activity
-		 FROM users u
-		 INNER JOIN user_pools up ON u.id = up.user_id
-		 INNER JOIN activity_logs al ON u.id = al.user_id
-		 WHERE up.pool_id = :poolId
-		   AND al.created_at >= :startDate
-		   AND al.created_at <= :cutoffTime
-		 GROUP BY u.id, u.username, u.first_name, u.last_name
-		 ORDER BY last_activity DESC`,
-		{ poolId, startDate, cutoffTime },
+		   mp.quorum_counted_at
+		 FROM meeting_participants mp
+		 INNER JOIN users u ON mp.user_id = u.id
+		 WHERE mp.meeting_id = :meetingId
+		   AND mp.role = 'voter'
+		   AND mp.quorum_counted_at IS NOT NULL
+		 ORDER BY mp.quorum_counted_at ASC`,
+		{ meetingId },
 	);
 
 	return result.rows.map((row) => ({
@@ -195,6 +177,6 @@ export async function getActiveVotersForQuorum(
 		username: row.username,
 		firstName: row.first_name,
 		lastName: row.last_name,
-		lastActivity: row.last_activity,
+		lastActivity: row.quorum_counted_at,
 	}));
 }

--- a/packages/server/src/services/watcher-service.ts
+++ b/packages/server/src/services/watcher-service.ts
@@ -34,6 +34,25 @@ const PAGE_OFFSET_ADJUSTMENT = 1;
 const DECIMAL_RADIX = 10;
 
 /**
+ * Check whether a user is authorized to view a specific meeting as a watcher,
+ * i.e. they are in the meeting's watcher_pool.
+ */
+export async function isUserAuthorizedForMeetingAsWatcher(
+	userId: string,
+	meetingId: number,
+): Promise<boolean> {
+	const result = await db.query<{ user_id: string }>(
+		`SELECT up.user_id
+		 FROM user_pools up
+		 INNER JOIN meetings m ON m.watcher_pool_id = up.pool_id
+		 WHERE m.id = :meetingId AND up.user_id = :userId
+		 LIMIT 1`,
+		{ meetingId, userId },
+	);
+	return result.rows.length > EMPTY_ARRAY_LENGTH;
+}
+
+/**
  * Get meetings with motion summaries for watcher view
  * Only returns meetings where the user is in the watcher pool
  */

--- a/packages/server/src/services/watcher-service.ts
+++ b/packages/server/src/services/watcher-service.ts
@@ -34,22 +34,27 @@ const PAGE_OFFSET_ADJUSTMENT = 1;
 const DECIMAL_RADIX = 10;
 
 /**
- * Get all meetings with motion summaries for watcher view
- * Watchers can see all meetings (not just active ones)
+ * Get meetings with motion summaries for watcher view
+ * Only returns meetings where the user is in the watcher pool
  */
 export async function getWatcherMeetings(
+	userId: string,
 	page = DEFAULT_PAGE,
 	limit = DEFAULT_LIMIT,
 ): Promise<{ meetings: WatcherMeetingReport[]; total: number }> {
 	const offset = (page - PAGE_OFFSET_ADJUSTMENT) * limit;
 
-	// Get total count
+	// Get total count for meetings where user is in the watcher pool
 	const countResult = await db.query<{ count: string }>(
-		"SELECT COUNT(*) as count FROM meetings",
+		`SELECT COUNT(*) as count FROM meetings m
+		 INNER JOIN user_pools up ON m.watcher_pool_id = up.pool_id
+		 WHERE up.user_id = :userId
+		   AND m.watcher_pool_id IS NOT NULL`,
+		{ userId },
 	);
 	const total = parseInt(countResult.rows[FIRST_ROW].count, DECIMAL_RADIX);
 
-	// Get paginated meetings with quorum pool names
+	// Get paginated meetings with quorum pool names, filtered by watcher pool membership
 	const meetingsResult = await db.query<{
 		id: number;
 		name: string;
@@ -63,9 +68,12 @@ export async function getWatcherMeetings(
 		        m.quorum_called_at, p.pool_name
 		 FROM meetings m
 		 INNER JOIN pools p ON m.quorum_voting_pool_id = p.id
+		 INNER JOIN user_pools up ON m.watcher_pool_id = up.pool_id
+		 WHERE up.user_id = :userId
+		   AND m.watcher_pool_id IS NOT NULL
 		 ORDER BY m.start_date DESC
 		 LIMIT :limit OFFSET :offset`,
-		{ limit, offset },
+		{ userId, limit, offset },
 	);
 
 	// For each meeting, get the motion summaries

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -350,6 +350,8 @@ export enum MotionStatus {
  * - start_date: TIMESTAMP WITH TIME ZONE NOT NULL
  * - end_date: TIMESTAMP WITH TIME ZONE NOT NULL
  * - quorum_voting_pool_id: INTEGER NOT NULL REFERENCES pools(id) ON DELETE RESTRICT
+ * - watcher_pool_id: INTEGER REFERENCES pools(id) ON DELETE RESTRICT (nullable)
+ * - admin_pool_id: INTEGER REFERENCES pools(id) ON DELETE RESTRICT (nullable)
  * - quorum_called_at: TIMESTAMP WITH TIME ZONE (nullable)
  * - created_at: TIMESTAMP WITH TIME ZONE
  * - updated_at: TIMESTAMP WITH TIME ZONE
@@ -363,6 +365,8 @@ export interface Meeting {
 	startDate: Date;
 	endDate: Date;
 	quorumVotingPoolId: number;
+	watcherPoolId: number | null;
+	adminPoolId: number | null;
 	quorumCalledAt: Date | null;
 	createdAt: Date;
 	updatedAt: Date;
@@ -373,6 +377,110 @@ export interface Meeting {
  */
 export interface MeetingWithPool extends Meeting {
 	quorumVotingPoolName: string;
+	watcherPoolName: string | null;
+	adminPoolName: string | null;
+}
+
+/**
+ * Participant role enum
+ * Represents the role of a user when they join a meeting
+ *
+ * Database enum (participant_role):
+ * - 'voter': Can vote on motions and counts toward quorum
+ * - 'watcher': Can observe meeting but cannot vote
+ * - 'meeting_admin': Can administer the meeting (scoped admin rights)
+ *
+ * IMPORTANT: Keep this enum in sync with database migrations
+ */
+export enum ParticipantRole {
+	Voter = "voter",
+	Watcher = "watcher",
+	MeetingAdmin = "meeting_admin",
+}
+
+/**
+ * Meeting participant interface
+ *
+ * Database schema (meeting_participants table):
+ * - id: SERIAL PRIMARY KEY
+ * - user_id: UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE
+ * - meeting_id: INTEGER NOT NULL REFERENCES meetings(id) ON DELETE CASCADE
+ * - role: participant_role NOT NULL
+ * - joined_at: TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+ * - left_at: TIMESTAMP WITH TIME ZONE (nullable, NULL if still active)
+ * - quorum_counted_at: TIMESTAMP WITH TIME ZONE (nullable, only for voters)
+ * - created_at: TIMESTAMP WITH TIME ZONE
+ * - updated_at: TIMESTAMP WITH TIME ZONE
+ *
+ * IMPORTANT: Keep this type in sync with database migrations
+ */
+export interface MeetingParticipant {
+	id: number;
+	userId: string;
+	meetingId: number;
+	role: ParticipantRole;
+	joinedAt: Date;
+	leftAt: Date | null;
+	quorumCountedAt: Date | null;
+	createdAt: Date;
+	updatedAt: Date;
+}
+
+/**
+ * Meeting available for a user to join
+ * Used in meeting selection screens for voters, watchers, and meeting admins
+ */
+export interface JoinableMeeting {
+	id: number;
+	name: string;
+	description: string | null;
+	startDate: Date;
+	endDate: Date;
+	quorumVotingPoolName: string;
+	/** Role the user would have if they join this meeting */
+	role: ParticipantRole;
+}
+
+/**
+ * Current meeting information for a user
+ * Returns the meeting the user is currently participating in
+ */
+export interface CurrentMeetingInfo {
+	meeting: MeetingWithPool;
+	participant: MeetingParticipant;
+}
+
+/**
+ * Response for joinable meetings list
+ */
+export interface JoinableMeetingsResponse {
+	data: JoinableMeeting[];
+}
+
+/**
+ * Response for current meeting endpoint
+ */
+export interface CurrentMeetingResponse {
+	data: CurrentMeetingInfo | null;
+}
+
+/**
+ * Response for joining a meeting
+ */
+export interface JoinMeetingResponse {
+	data: {
+		participant: MeetingParticipant;
+		meeting: MeetingWithPool;
+	};
+}
+
+/**
+ * Response for leaving a meeting
+ */
+export interface LeaveMeetingResponse {
+	data: {
+		success: boolean;
+	};
 }
 
 /**
@@ -449,6 +557,8 @@ export interface CreateMeetingRequest {
 	startDate: string; // ISO 8601 string
 	endDate: string; // ISO 8601 string
 	quorumVotingPoolId: number;
+	watcherPoolId?: number | null;
+	adminPoolId?: number | null;
 }
 
 /**
@@ -460,6 +570,8 @@ export interface UpdateMeetingRequest {
 	startDate?: string; // ISO 8601 string
 	endDate?: string; // ISO 8601 string
 	quorumVotingPoolId?: number;
+	watcherPoolId?: number | null;
+	adminPoolId?: number | null;
 }
 
 /**
@@ -624,6 +736,7 @@ export interface AuthUser {
 	lastName: string;
 	isAdmin: boolean;
 	isWatcher: boolean;
+	isMeetingAdmin: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR implements comprehensive meeting-based user access control as described in Issue #96. All user types (voters, watchers, and meeting administrators) now explicitly join meetings rather than having system-wide access.

### Phase 1: Voter Meeting Access & Quorum
- Added `meeting_participants` table to track explicit meeting participation
- Users join meetings from the quorum pool; quorum counts explicit joins (not activity logs)
- Voters can only see motions from their currently joined meeting
- Meeting selection page shown after login when no meeting is joined

### Phase 2: Watcher Meeting Access
- Added `watcher_pool_id` to meetings for watcher access control
- Watchers join meetings via watcher pool
- Watcher reports scoped to joined meeting only

### Phase 3: Meeting Administrator Role
- Added `admin_pool_id` to meetings for meeting admin access control
- Meeting admins have scoped access to their assigned meetings
- Global admins can join any active meeting regardless of pool membership
- Dynamic Join/Leave Meeting menu toggle in admin navigation
- Meeting list filtering when in "joined mode"
- Header shows "Meeting Admin" for non-global admins

### Self-Protection Features
- Admins cannot disable their own account
- Meeting admins cannot remove themselves from their joined meeting's admin pool
- Meeting session cleared on login so users start fresh each time

## Database Migrations
- `0013-add-meeting-participants.sql` - Creates meeting participation tracking table
- `0014-add-watcher-pool-to-meetings.sql` - Adds watcher pool reference to meetings
- `0015-add-admin-pool-to-meetings.sql` - Adds admin pool reference to meetings

## Test plan
- [x] Login as voter - redirected to meeting selection page
- [x] Join meeting as voter - can see motions for that meeting only
- [x] Quorum correctly counts joined voters
- [x] Login as watcher - redirected to meeting selection page
- [x] Join meeting as watcher - reports scoped to that meeting
- [x] Login as meeting admin - can join assigned meetings
- [x] Login as global admin - can join any active meeting
- [x] Join/Leave menu toggle works correctly
- [x] Meeting list filters when joined
- [x] Cannot disable own account
- [x] Cannot remove self from joined meeting's admin pool
- [x] Meeting session clears on fresh login

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)