### PR TITLE
Remove engines block to fix DO build

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,5 @@
 		"prettier": "^3.4.2",
 		"typescript": "^5.7.2",
 		"typescript-eslint": "^8.51.0"
-	},
-	"engines": {
-		"node": ">=22.12.0",
-		"npm": ">=10.0.0"
 	}
 }


### PR DESCRIPTION
## Summary
- The DO App Platform buildpack was failing on `engines.node: ">=22.12.0"` (flagged as a "dangerous wide range") and was trying to bootstrap a newer npm to satisfy `engines.npm: ">=10.0.0"`, which crashed with `Cannot find module 'promise-retry'`.
- Removed the `engines` block entirely. `.node-version` (22.12.0) already pins Node for both local dev tools and the buildpack's fallback resolution, and each Node version ships with a compatible bundled npm — so the block was redundant and its npm range was actively breaking the build.

## Test plan
- [ ] DO build succeeds on this branch (no `MODULE_NOT_FOUND: promise-retry`, no wide-range warning).
- [ ] Local `npm ci` still works on Node 22.12.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)