### PR TITLE
Implement multiple voter pools per meeting (#91)

### DIFF
--- a/packages/client/src/composables/useAdminMeeting.ts
+++ b/packages/client/src/composables/useAdminMeeting.ts
@@ -33,7 +33,7 @@ export function useAdminMeeting(): {
 		() => currentMeeting.value?.meeting.id ?? null,
 	);
 	const joinedMeetingAdminPoolId = computed(
-		() => currentMeeting.value?.meeting.adminPoolId ?? null,
+		() => currentMeeting.value?.meeting.meetingAdminPoolId ?? null,
 	);
 
 	/**

--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -615,6 +615,34 @@ export async function deleteMeeting(id: number): Promise<ApiResponse<void>> {
 }
 
 /**
+ * Get voter pools for a meeting
+ */
+export async function getMeetingVoterPools(
+	meetingId: number,
+): Promise<ApiResponse<number[]>> {
+	return await apiRequest<ApiResponse<number[]>>(
+		`${API_PREFIX}/admin/meetings/${meetingId}/voter-pools`,
+	);
+}
+
+/**
+ * Update voter pools for a meeting
+ * Note: The quorum pool is always included automatically by the backend
+ */
+export async function updateMeetingVoterPools(
+	meetingId: number,
+	poolIds: number[],
+): Promise<ApiResponse<number[]>> {
+	return await apiRequest<ApiResponse<number[]>>(
+		`${API_PREFIX}/admin/meetings/${meetingId}/voter-pools`,
+		{
+			method: "PUT",
+			body: JSON.stringify({ poolIds }),
+		},
+	);
+}
+
+/**
  * Motion Management API Functions
  */
 

--- a/packages/client/src/views/admin/MeetingCreate.vue
+++ b/packages/client/src/views/admin/MeetingCreate.vue
@@ -20,8 +20,6 @@ const formData = ref({
 	startDate: EMPTY_STRING,
 	endDate: EMPTY_STRING,
 	quorumVotingPoolId: EMPTY_STRING,
-	watcherPoolId: EMPTY_STRING,
-	adminPoolId: EMPTY_STRING,
 });
 
 const saving = ref(false);
@@ -45,8 +43,6 @@ interface FormDataType {
 	startDate: string;
 	endDate: string;
 	quorumVotingPoolId: string;
-	watcherPoolId: string;
-	adminPoolId: string;
 }
 
 function validateFormData(data: FormDataType): string | null {
@@ -95,12 +91,6 @@ async function handleSubmit(): Promise<void> {
 			),
 			...(formData.value.description.trim() !== EMPTY_STRING && {
 				description: formData.value.description.trim(),
-			}),
-			...(formData.value.watcherPoolId !== EMPTY_STRING && {
-				watcherPoolId: Number.parseInt(formData.value.watcherPoolId, 10),
-			}),
-			...(formData.value.adminPoolId !== EMPTY_STRING && {
-				adminPoolId: Number.parseInt(formData.value.adminPoolId, 10),
 			}),
 		};
 
@@ -193,48 +183,26 @@ onMounted(() => {
 				</p>
 			</div>
 
-			<div class="form-group">
-				<label for="watcherPoolId">
-					Watcher Pool
-					<span class="optional">(optional)</span>
-				</label>
-				<select
-					id="watcherPoolId"
-					v-model="formData.watcherPoolId"
-					:disabled="loadingPools"
-				>
-					<option value="">
-						{{ loadingPools ? "Loading pools..." : "No watcher pool" }}
-					</option>
-					<option v-for="pool in pools" :key="pool.id" :value="pool.id">
-						{{ pool.poolName }}
-					</option>
-				</select>
-				<p class="field-description">
-					Optional pool of users who can observe this meeting as watchers
+			<div class="info-box">
+				<strong>Auto-Created Pools</strong>
+				<p>
+					The following pools will be automatically created when this meeting is
+					saved:
 				</p>
-			</div>
-
-			<div class="form-group">
-				<label for="adminPoolId">
-					Admin Pool
-					<span class="optional">(optional)</span>
-				</label>
-				<select
-					id="adminPoolId"
-					v-model="formData.adminPoolId"
-					:disabled="loadingPools"
-				>
-					<option value="">
-						{{ loadingPools ? "Loading pools..." : "No admin pool" }}
-					</option>
-					<option v-for="pool in pools" :key="pool.id" :value="pool.id">
-						{{ pool.poolName }}
-					</option>
-				</select>
-				<p class="field-description">
-					Optional pool of users who can administer this meeting (global admins
-					always have access)
+				<ul>
+					<li>
+						<strong>{{ formData.name || "Meeting Name" }} - Watchers</strong> -
+						Users in this pool can observe the meeting
+					</li>
+					<li>
+						<strong
+							>{{ formData.name || "Meeting Name" }} - Meeting Admins</strong
+						>
+						- Users in this pool can administer the meeting
+					</li>
+				</ul>
+				<p class="info-note">
+					You can add users to these pools after the meeting is created.
 				</p>
 			</div>
 
@@ -356,5 +324,38 @@ h2 {
 
 .btn-secondary:hover:not(:disabled) {
 	background-color: #616161;
+}
+
+.info-box {
+	background-color: #e3f2fd;
+	border: 1px solid #90caf9;
+	border-radius: 4px;
+	padding: 1rem;
+	margin-bottom: 1.5rem;
+}
+
+.info-box strong {
+	color: #1565c0;
+}
+
+.info-box p {
+	margin: 0.5rem 0;
+	color: #424242;
+}
+
+.info-box ul {
+	margin: 0.5rem 0;
+	padding-left: 1.5rem;
+}
+
+.info-box li {
+	margin: 0.25rem 0;
+	color: #424242;
+}
+
+.info-note {
+	font-size: 0.875rem;
+	font-style: italic;
+	color: #666 !important;
 }
 </style>

--- a/packages/client/src/views/admin/MeetingEdit.vue
+++ b/packages/client/src/views/admin/MeetingEdit.vue
@@ -1,7 +1,14 @@
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
+import { ref, onMounted, computed, watch } from "vue";
 import { useRouter } from "vue-router";
-import { getMeeting, updateMeeting, getPools } from "../../services/api";
+import {
+	getMeeting,
+	updateMeeting,
+	getPools,
+	getMeetingVoterPools,
+	updateMeetingVoterPools,
+	createPool,
+} from "../../services/api";
 import { useAuth } from "../../composables/useAuth";
 import type { Pool } from "@mcdc-convention-voting/shared";
 
@@ -31,12 +38,44 @@ const formData = ref({
 	endDate: EMPTY_STRING,
 	quorumVotingPoolId: EMPTY_STRING,
 	watcherPoolId: EMPTY_STRING,
-	adminPoolId: EMPTY_STRING,
+	meetingAdminPoolId: EMPTY_STRING,
 });
 
 const loading = ref(false);
 const saving = ref(false);
 const error = ref<string | null>(null);
+
+// Voter pools state
+const selectedVoterPoolIds = ref<Set<number>>(new Set());
+const loadingVoterPools = ref(false);
+
+// Create pool modal state
+const showCreatePoolModal = ref(false);
+const createPoolName = ref(EMPTY_STRING);
+const createPoolKey = ref(EMPTY_STRING);
+const createPoolDescription = ref(EMPTY_STRING);
+const createPoolLoading = ref(false);
+
+// Check if a pool is the quorum pool (always checked/disabled)
+const isQuorumPool = computed(() => (poolId: number): boolean => {
+	const quorumId = Number.parseInt(
+		formData.value.quorumVotingPoolId,
+		DECIMAL_RADIX,
+	);
+	return !Number.isNaN(quorumId) && poolId === quorumId;
+});
+
+// Sync quorum pool changes to selectedVoterPoolIds
+watch(
+	() => formData.value.quorumVotingPoolId,
+	(newQuorumPoolId) => {
+		const newId = Number.parseInt(newQuorumPoolId, DECIMAL_RADIX);
+		if (!Number.isNaN(newId)) {
+			selectedVoterPoolIds.value.add(newId);
+			selectedVoterPoolIds.value = new Set(selectedVoterPoolIds.value);
+		}
+	},
+);
 
 function formatDateForInput(date: Date | string): string {
 	const d = new Date(date);
@@ -89,16 +128,115 @@ async function loadMeeting(): Promise<void> {
 					meeting.watcherPoolId === null
 						? EMPTY_STRING
 						: String(meeting.watcherPoolId),
-				adminPoolId:
-					meeting.adminPoolId === null
+				meetingAdminPoolId:
+					meeting.meetingAdminPoolId === null
 						? EMPTY_STRING
-						: String(meeting.adminPoolId),
+						: String(meeting.meetingAdminPoolId),
 			};
 		}
 	} catch (err) {
 		error.value = err instanceof Error ? err.message : "Failed to load meeting";
 	} finally {
 		loading.value = false;
+	}
+}
+
+async function loadVoterPools(): Promise<void> {
+	const meetingId = Number.parseInt(props.id, DECIMAL_RADIX);
+	if (Number.isNaN(meetingId)) return;
+
+	loadingVoterPools.value = true;
+	try {
+		const response = await getMeetingVoterPools(meetingId);
+		if (response.data !== undefined) {
+			selectedVoterPoolIds.value = new Set(response.data);
+		}
+	} catch {
+		// Non-critical: voter pools section can still work
+		// Error is ignored as this is a secondary data load
+	} finally {
+		loadingVoterPools.value = false;
+	}
+}
+
+function toggleVoterPool(poolId: number): void {
+	// Cannot toggle the quorum pool - it's always checked
+	if (isQuorumPool.value(poolId)) return;
+
+	if (selectedVoterPoolIds.value.has(poolId)) {
+		selectedVoterPoolIds.value.delete(poolId);
+	} else {
+		selectedVoterPoolIds.value.add(poolId);
+	}
+	// Force reactivity
+	selectedVoterPoolIds.value = new Set(selectedVoterPoolIds.value);
+}
+
+/**
+ * Generate a pool key from meeting name (client-side)
+ * Matches the backend pattern: slugify + suffix
+ */
+function generatePoolKeyFromName(name: string, suffix = "pool"): string {
+	const slug = name
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/(?:^-|-$)/g, "");
+	return `${slug}-${suffix}`;
+}
+
+function openCreatePoolModal(): void {
+	const meetingName = formData.value.name;
+	const suggestedKey = generatePoolKeyFromName(meetingName, "voters");
+
+	createPoolKey.value = suggestedKey;
+	createPoolName.value = `${meetingName} - Additional Voters`;
+	createPoolDescription.value = EMPTY_STRING;
+	showCreatePoolModal.value = true;
+}
+
+function closeCreatePoolModal(): void {
+	showCreatePoolModal.value = false;
+	createPoolKey.value = EMPTY_STRING;
+	createPoolName.value = EMPTY_STRING;
+	createPoolDescription.value = EMPTY_STRING;
+}
+
+async function handleCreatePool(): Promise<void> {
+	if (createPoolName.value.trim() === EMPTY_STRING) {
+		error.value = "Pool name is required";
+		return;
+	}
+	if (createPoolKey.value.trim() === EMPTY_STRING) {
+		error.value = "Pool key is required";
+		return;
+	}
+
+	createPoolLoading.value = true;
+	error.value = null;
+
+	try {
+		const trimmedDescription = createPoolDescription.value.trim();
+		const result = await createPool({
+			poolKey: createPoolKey.value.trim(),
+			poolName: createPoolName.value.trim(),
+			description:
+				trimmedDescription === EMPTY_STRING ? undefined : trimmedDescription,
+		});
+
+		if (result.data !== undefined) {
+			// Refresh pools list
+			await loadPools();
+
+			// Auto-check the new pool
+			selectedVoterPoolIds.value.add(result.data.id);
+			selectedVoterPoolIds.value = new Set(selectedVoterPoolIds.value);
+		}
+
+		closeCreatePoolModal();
+	} catch (err) {
+		error.value = err instanceof Error ? err.message : "Failed to create pool";
+	} finally {
+		createPoolLoading.value = false;
 	}
 }
 
@@ -109,7 +247,7 @@ interface FormDataType {
 	endDate: string;
 	quorumVotingPoolId: string;
 	watcherPoolId: string;
-	adminPoolId: string;
+	meetingAdminPoolId: string;
 }
 
 function validateFormData(data: FormDataType): string | null {
@@ -164,13 +302,20 @@ async function handleSubmit(): Promise<void> {
 				formData.value.watcherPoolId === EMPTY_STRING
 					? null
 					: Number.parseInt(formData.value.watcherPoolId, DECIMAL_RADIX),
-			adminPoolId:
-				formData.value.adminPoolId === EMPTY_STRING
+			meetingAdminPoolId:
+				formData.value.meetingAdminPoolId === EMPTY_STRING
 					? null
-					: Number.parseInt(formData.value.adminPoolId, DECIMAL_RADIX),
+					: Number.parseInt(formData.value.meetingAdminPoolId, DECIMAL_RADIX),
 		};
 
 		await updateMeeting(meetingId, meetingData);
+
+		// Save voter pools (quorum pool automatically included by backend)
+		await updateMeetingVoterPools(
+			meetingId,
+			Array.from(selectedVoterPoolIds.value),
+		);
+
 		void router.push("/admin/meetings");
 	} catch (err) {
 		error.value =
@@ -187,6 +332,7 @@ function cancel(): void {
 onMounted(() => {
 	void loadPools();
 	void loadMeeting();
+	void loadVoterPools();
 });
 </script>
 
@@ -278,13 +424,13 @@ onMounted(() => {
 			</div>
 
 			<div class="form-group">
-				<label for="adminPoolId">
-					Admin Pool
+				<label for="meetingAdminPoolId">
+					Meeting Admin Pool
 					<span class="optional">(optional)</span>
 				</label>
 				<select
-					id="adminPoolId"
-					v-model="formData.adminPoolId"
+					id="meetingAdminPoolId"
+					v-model="formData.meetingAdminPoolId"
 					:disabled="loadingPools || !isAdmin"
 				>
 					<option value="">
@@ -299,8 +445,53 @@ onMounted(() => {
 					always have access)
 				</p>
 				<p v-if="!isAdmin" class="field-restriction">
-					Only global administrators can change the Admin Pool.
+					Only global administrators can change the Meeting Admin Pool.
 				</p>
+			</div>
+
+			<div class="form-group">
+				<label>
+					Voter Pools
+					<span class="optional">(voters from these pools can vote)</span>
+				</label>
+				<p class="field-description">
+					Select which pools can vote in this meeting. The quorum pool is always
+					included.
+				</p>
+
+				<div v-if="loadingPools || loadingVoterPools" class="loading-inline">
+					Loading pools...
+				</div>
+
+				<div v-else class="voter-pools-grid">
+					<label
+						v-for="pool in pools"
+						:key="pool.id"
+						class="pool-checkbox"
+						:class="{ 'pool-checkbox-disabled': isQuorumPool(pool.id) }"
+					>
+						<input
+							type="checkbox"
+							:checked="
+								selectedVoterPoolIds.has(pool.id) || isQuorumPool(pool.id)
+							"
+							:disabled="isQuorumPool(pool.id)"
+							@change="toggleVoterPool(pool.id)"
+						/>
+						<span class="pool-name">{{ pool.poolName }}</span>
+						<span v-if="isQuorumPool(pool.id)" class="quorum-badge"
+							>(Quorum Pool)</span
+						>
+					</label>
+				</div>
+
+				<button
+					type="button"
+					class="btn btn-small btn-outline"
+					@click="openCreatePoolModal"
+				>
+					+ Create New Pool
+				</button>
 			</div>
 
 			<div class="form-actions">
@@ -312,6 +503,64 @@ onMounted(() => {
 				</button>
 			</div>
 		</form>
+
+		<!-- Create Pool Modal -->
+		<div v-if="showCreatePoolModal" class="modal" @click="closeCreatePoolModal">
+			<div class="modal-content" @click.stop>
+				<h3>Create New Pool</h3>
+				<p>Create a new voter pool for this meeting.</p>
+
+				<div class="form-group">
+					<label for="newPoolName">
+						Pool Name <span class="required">*</span>
+					</label>
+					<input
+						id="newPoolName"
+						v-model="createPoolName"
+						type="text"
+						placeholder="Display name for the pool"
+					/>
+				</div>
+
+				<div class="form-group">
+					<label for="newPoolKey">
+						Pool Key <span class="required">*</span>
+					</label>
+					<input
+						id="newPoolKey"
+						v-model="createPoolKey"
+						type="text"
+						placeholder="Unique identifier (auto-generated)"
+					/>
+					<p class="field-description">
+						Unique identifier used for CSV imports and API references
+					</p>
+				</div>
+
+				<div class="form-group">
+					<label for="newPoolDescription">Description</label>
+					<textarea
+						id="newPoolDescription"
+						v-model="createPoolDescription"
+						rows="2"
+						placeholder="Optional description"
+					/>
+				</div>
+
+				<div class="modal-actions">
+					<button
+						class="btn btn-primary"
+						:disabled="createPoolLoading"
+						@click="handleCreatePool"
+					>
+						{{ createPoolLoading ? "Creating..." : "Create Pool" }}
+					</button>
+					<button class="btn btn-secondary" @click="closeCreatePoolModal">
+						Cancel
+					</button>
+				</div>
+			</div>
+		</div>
 	</div>
 </template>
 
@@ -434,5 +683,117 @@ h2 {
 	font-size: 0.875rem;
 	color: #e65100;
 	font-style: italic;
+}
+
+/* Voter pools grid */
+.voter-pools-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+	gap: 0.75rem;
+	margin-bottom: 1rem;
+	padding: 1rem;
+	background-color: #f8f9fa;
+	border-radius: 4px;
+	max-height: 300px;
+	overflow-y: auto;
+}
+
+.pool-checkbox {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.5rem;
+	background-color: white;
+	border-radius: 4px;
+	cursor: pointer;
+	border: 1px solid #e0e0e0;
+	transition: border-color 0.2s;
+}
+
+.pool-checkbox:hover:not(.pool-checkbox-disabled) {
+	border-color: #1976d2;
+}
+
+.pool-checkbox-disabled {
+	background-color: #e3f2fd;
+	cursor: not-allowed;
+}
+
+.pool-checkbox input[type="checkbox"] {
+	width: auto;
+	margin: 0;
+}
+
+.pool-name {
+	flex: 1;
+	font-size: 0.875rem;
+}
+
+.quorum-badge {
+	font-size: 0.75rem;
+	color: #1976d2;
+	font-weight: 500;
+}
+
+.btn-small {
+	padding: 0.5rem 1rem;
+	font-size: 0.875rem;
+}
+
+.btn-outline {
+	background-color: transparent;
+	border: 1px solid #1976d2;
+	color: #1976d2;
+}
+
+.btn-outline:hover {
+	background-color: #e3f2fd;
+}
+
+.loading-inline {
+	padding: 1rem;
+	color: #666;
+	text-align: center;
+}
+
+/* Modal styles */
+.modal {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: rgba(0, 0, 0, 0.5);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 1000;
+}
+
+.modal-content {
+	background-color: white;
+	padding: 2rem;
+	border-radius: 8px;
+	max-width: 500px;
+	width: 90%;
+	box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.modal-content h3 {
+	margin: 0 0 1rem 0;
+	color: #2c3e50;
+}
+
+.modal-content > p {
+	margin: 0 0 1.5rem 0;
+	color: #666;
+	line-height: 1.5;
+}
+
+.modal-actions {
+	display: flex;
+	gap: 1rem;
+	justify-content: flex-end;
+	margin-top: 1.5rem;
 }
 </style>

--- a/packages/client/src/views/admin/UserCreate.vue
+++ b/packages/client/src/views/admin/UserCreate.vue
@@ -9,7 +9,7 @@ const router = useRouter();
 const EMPTY_STRING = "";
 
 // User role options
-type UserRole = "voter" | "admin" | "watcher";
+type UserRole = "voter" | "admin" | "watcher" | "meeting_admin";
 
 const formData = ref({
 	voterId: EMPTY_STRING,
@@ -46,6 +46,7 @@ async function handleSubmit(): Promise<void> {
 			}),
 			isAdmin: formData.value.role === "admin",
 			isWatcher: formData.value.role === "watcher",
+			isMeetingAdmin: formData.value.role === "meeting_admin",
 		};
 
 		await createUser(userData);
@@ -110,7 +111,8 @@ function cancel(): void {
 				<select id="role" v-model="formData.role" required>
 					<option value="voter">Voter</option>
 					<option value="watcher">Watcher (Observer)</option>
-					<option value="admin">Admin</option>
+					<option value="meeting_admin">Meeting Admin</option>
+					<option value="admin">Global Admin</option>
 				</select>
 				<p class="role-description">
 					<template v-if="formData.role === 'voter'">
@@ -120,9 +122,14 @@ function cancel(): void {
 						Watchers have read-only access to meeting reports, quorum status,
 						and completed motion results. They cannot vote.
 					</template>
+					<template v-else-if="formData.role === 'meeting_admin'">
+						Meeting Admins can manage meetings they are assigned to (motions,
+						quorum, reports). They must be added to a meeting's admin pool. They
+						cannot vote.
+					</template>
 					<template v-else-if="formData.role === 'admin'">
-						Admins can manage users, meetings, motions, and system settings.
-						They cannot vote.
+						Global Admins can manage all users, meetings, motions, and system
+						settings. They have access to all meetings. They cannot vote.
 					</template>
 				</p>
 			</div>

--- a/packages/server/src/database/migrations/0016-multiple-voter-pools.sql
+++ b/packages/server/src/database/migrations/0016-multiple-voter-pools.sql
@@ -1,0 +1,49 @@
+-- Migration: Multiple voter pools per meeting and meeting admin enhancements
+-- Part of Issue #91 Part 2
+
+-- 1. Create junction table for multiple voter pools per meeting
+CREATE TABLE meeting_voter_pools (
+  id SERIAL PRIMARY KEY,
+  meeting_id INTEGER NOT NULL REFERENCES meetings(id) ON DELETE CASCADE,
+  pool_id INTEGER NOT NULL REFERENCES pools(id) ON DELETE RESTRICT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  UNIQUE (meeting_id, pool_id)
+);
+
+CREATE INDEX idx_meeting_voter_pools_meeting ON meeting_voter_pools(meeting_id);
+CREATE INDEX idx_meeting_voter_pools_pool ON meeting_voter_pools(pool_id);
+
+COMMENT ON TABLE meeting_voter_pools IS 'Junction table for associating multiple voter pools with a meeting';
+COMMENT ON COLUMN meeting_voter_pools.meeting_id IS 'Reference to meeting';
+COMMENT ON COLUMN meeting_voter_pools.pool_id IS 'Reference to voter pool';
+
+-- 2. Rename admin_pool_id to meeting_admin_pool_id for clarity
+ALTER TABLE meetings RENAME COLUMN admin_pool_id TO meeting_admin_pool_id;
+
+-- Update comment for renamed column
+COMMENT ON COLUMN meetings.meeting_admin_pool_id IS 'Auto-created pool of users who can administer this meeting (nullable)';
+
+-- 3. Add is_meeting_admin user flag
+ALTER TABLE users ADD COLUMN is_meeting_admin BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX idx_users_meeting_admin ON users(is_meeting_admin);
+
+-- 4. Update role exclusivity constraint to include meeting_admin
+-- First drop the existing constraint
+ALTER TABLE users DROP CONSTRAINT users_role_exclusivity;
+
+-- Add new constraint that includes meeting_admin
+ALTER TABLE users ADD CONSTRAINT users_role_exclusivity CHECK (
+  -- Only one of the three special roles can be true
+  (CASE WHEN is_admin THEN 1 ELSE 0 END +
+   CASE WHEN is_watcher THEN 1 ELSE 0 END +
+   CASE WHEN is_meeting_admin THEN 1 ELSE 0 END) <= 1
+);
+
+COMMENT ON COLUMN users.is_meeting_admin IS 'Whether user has meeting admin privileges (can administer assigned meetings). A user can only be admin, watcher, meeting_admin, or voter (mutually exclusive roles).';
+COMMENT ON CONSTRAINT users_role_exclusivity ON users IS 'Ensures a user can only have one special role: global admin, watcher, or meeting admin. Regular voters have all flags set to FALSE.';
+
+-- 5. Migrate existing data: add quorum pools to junction table
+-- This ensures existing meetings have their quorum pool in the voter pools list
+INSERT INTO meeting_voter_pools (meeting_id, pool_id)
+SELECT id, quorum_voting_pool_id FROM meetings WHERE quorum_voting_pool_id IS NOT NULL;

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -64,6 +64,8 @@ import {
 	listMeetingsForMeetingAdmin,
 	updateMeeting,
 	deleteMeeting,
+	getVoterPoolsForMeeting,
+	setVoterPoolsForMeeting,
 	createMotion,
 	getMotionById,
 	getMotionDetailedResults,
@@ -988,8 +990,8 @@ adminRouter.put(
 				updates.poolKey = trimmedPoolKey;
 			}
 
-			const pool = await updatePool(poolId, updates);
-			res.json({ success: true, data: pool });
+			const { pool, resolvedUsers } = await updatePool(poolId, updates);
+			res.json({ success: true, data: pool, resolvedUsers });
 		} catch (error) {
 			const message = error instanceof Error ? error.message : "Unknown error";
 			res
@@ -1129,7 +1131,7 @@ adminRouter.delete(
 				if (
 					currentMeeting !== null &&
 					currentMeeting.participant.role === ParticipantRole.MeetingAdmin &&
-					currentMeeting.meeting.adminPoolId === poolId
+					currentMeeting.meeting.meetingAdminPoolId === poolId
 				) {
 					res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
 						success: false,
@@ -1217,7 +1219,7 @@ adminRouter.post(
 				endDate: request.endDate,
 				quorumVotingPoolId: request.quorumVotingPoolId,
 				watcherPoolId: request.watcherPoolId,
-				adminPoolId: request.adminPoolId,
+				meetingAdminPoolId: request.meetingAdminPoolId,
 				description: request.description,
 			};
 
@@ -1419,11 +1421,11 @@ adminRouter.put(
 			const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
 			const updates: UpdateMeetingRequest = req.body;
-			// Only global admins may change the admin pool for a meeting.
-			// Strip adminPoolId from the update payload for non-global-admins so a
+			// Only global admins may change the meeting admin pool for a meeting.
+			// Strip meetingAdminPoolId from the update payload for non-global-admins so a
 			// scoped meeting admin can't grant admin rights to others.
-			if (req.user?.isAdmin !== true && "adminPoolId" in updates) {
-				delete updates.adminPoolId;
+			if (req.user?.isAdmin !== true && "meetingAdminPoolId" in updates) {
+				delete updates.meetingAdminPoolId;
 			}
 			const meeting = await updateMeeting(meetingId, updates);
 			res.json({ success: true, data: meeting });
@@ -1494,6 +1496,84 @@ adminRouter.post(
 			res
 				.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR)
 				.json({ success: false, error: `Failed to join meeting: ${message}` });
+		}
+	},
+);
+
+/**
+ * Voter Pool Management Routes
+ */
+
+/**
+ * GET /api/admin/meetings/:id/voter-pools
+ * Get voter pools for a meeting
+ */
+adminRouter.get(
+	"/meetings/:id/voter-pools",
+	requireMeetingAdmin("id"),
+	async (req: Request, res: Response) => {
+		try {
+			const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
+			if (Number.isNaN(meetingId)) {
+				res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+					success: false,
+					error: "Invalid meeting ID",
+				});
+				return;
+			}
+
+			const voterPoolIds = await getVoterPoolsForMeeting(meetingId);
+			res.json({ success: true, data: voterPoolIds });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR).json({
+				success: false,
+				error: `Failed to get voter pools: ${message}`,
+			});
+		}
+	},
+);
+
+/**
+ * PUT /api/admin/meetings/:id/voter-pools
+ * Set voter pools for a meeting (quorum pool always included)
+ */
+adminRouter.put(
+	"/meetings/:id/voter-pools",
+	requireMeetingAdmin("id"),
+	async (req: Request, res: Response) => {
+		try {
+			const meetingId = parseInt(req.params.id, DECIMAL_RADIX);
+			if (Number.isNaN(meetingId)) {
+				res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+					success: false,
+					error: "Invalid meeting ID",
+				});
+				return;
+			}
+
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
+			const body: { poolIds?: number[] } = req.body;
+
+			if (!Array.isArray(body.poolIds)) {
+				res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({
+					success: false,
+					error: "poolIds must be an array of numbers",
+				});
+				return;
+			}
+
+			const voterPoolIds = await setVoterPoolsForMeeting(
+				meetingId,
+				body.poolIds,
+			);
+			res.json({ success: true, data: voterPoolIds });
+		} catch (error) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			res.status(HTTP_STATUS.SERVER_ERROR.INTERNAL_SERVER_ERROR).json({
+				success: false,
+				error: `Failed to set voter pools: ${message}`,
+			});
 		}
 	},
 );

--- a/packages/server/src/services/auth-service.ts
+++ b/packages/server/src/services/auth-service.ts
@@ -24,7 +24,7 @@ async function isUserMeetingAdminForAnyMeeting(
 	const result = await db.query<{ exists: boolean }>(
 		`SELECT EXISTS(
 			SELECT 1 FROM user_pools up
-			INNER JOIN meetings m ON m.admin_pool_id = up.pool_id
+			INNER JOIN meetings m ON m.meeting_admin_pool_id = up.pool_id
 			WHERE up.user_id = :userId
 			  AND NOW() >= m.start_date
 			  AND NOW() <= m.end_date

--- a/packages/server/src/services/meeting-participant-service.ts
+++ b/packages/server/src/services/meeting-participant-service.ts
@@ -93,22 +93,22 @@ export async function getCurrentMeetingInfo(
 		end_date: Date;
 		quorum_voting_pool_id: number;
 		watcher_pool_id: number | null;
-		admin_pool_id: number | null;
+		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
 		created_at: Date;
 		updated_at: Date;
 		quorum_pool_name: string;
 		watcher_pool_name: string | null;
-		admin_pool_name: string | null;
+		meeting_admin_pool_name: string | null;
 	}>(
 		`SELECT m.*,
 		        qp.pool_name as quorum_pool_name,
 		        wp.pool_name as watcher_pool_name,
-		        ap.pool_name as admin_pool_name
+		        ap.pool_name as meeting_admin_pool_name
 		 FROM meetings m
 		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
 		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
-		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
+		 LEFT JOIN pools ap ON m.meeting_admin_pool_id = ap.id
 		 WHERE m.id = :meetingId`,
 		{ meetingId: participation.meetingId },
 	);
@@ -128,13 +128,13 @@ export async function getCurrentMeetingInfo(
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
 		watcherPoolId: row.watcher_pool_id,
-		adminPoolId: row.admin_pool_id,
+		meetingAdminPoolId: row.meeting_admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 		quorumVotingPoolName: row.quorum_pool_name,
 		watcherPoolName: row.watcher_pool_name,
-		adminPoolName: row.admin_pool_name,
+		meetingAdminPoolName: row.meeting_admin_pool_name,
 	};
 
 	return {
@@ -208,22 +208,22 @@ export async function joinMeetingAsVoter(
 		end_date: Date;
 		quorum_voting_pool_id: number;
 		watcher_pool_id: number | null;
-		admin_pool_id: number | null;
+		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
 		created_at: Date;
 		updated_at: Date;
 		quorum_pool_name: string;
 		watcher_pool_name: string | null;
-		admin_pool_name: string | null;
+		meeting_admin_pool_name: string | null;
 	}>(
 		`SELECT m.*,
 		        qp.pool_name as quorum_pool_name,
 		        wp.pool_name as watcher_pool_name,
-		        ap.pool_name as admin_pool_name
+		        ap.pool_name as meeting_admin_pool_name
 		 FROM meetings m
 		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
 		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
-		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
+		 LEFT JOIN pools ap ON m.meeting_admin_pool_id = ap.id
 		 WHERE m.id = :meetingId
 		   AND NOW() >= m.start_date
 		   AND NOW() <= m.end_date`,
@@ -296,13 +296,13 @@ export async function joinMeetingAsVoter(
 		endDate: meetingRow.end_date,
 		quorumVotingPoolId: meetingRow.quorum_voting_pool_id,
 		watcherPoolId: meetingRow.watcher_pool_id,
-		adminPoolId: meetingRow.admin_pool_id,
+		meetingAdminPoolId: meetingRow.meeting_admin_pool_id,
 		quorumCalledAt: meetingRow.quorum_called_at,
 		createdAt: meetingRow.created_at,
 		updatedAt: meetingRow.updated_at,
 		quorumVotingPoolName: meetingRow.quorum_pool_name,
 		watcherPoolName: meetingRow.watcher_pool_name,
-		adminPoolName: meetingRow.admin_pool_name,
+		meetingAdminPoolName: meetingRow.meeting_admin_pool_name,
 	};
 
 	return { participant, meeting };
@@ -458,22 +458,22 @@ export async function joinMeetingAsWatcher(
 		end_date: Date;
 		quorum_voting_pool_id: number;
 		watcher_pool_id: number | null;
-		admin_pool_id: number | null;
+		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
 		created_at: Date;
 		updated_at: Date;
 		quorum_pool_name: string;
 		watcher_pool_name: string | null;
-		admin_pool_name: string | null;
+		meeting_admin_pool_name: string | null;
 	}>(
 		`SELECT m.*,
 		        qp.pool_name as quorum_pool_name,
 		        wp.pool_name as watcher_pool_name,
-		        ap.pool_name as admin_pool_name
+		        ap.pool_name as meeting_admin_pool_name
 		 FROM meetings m
 		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
 		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
-		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
+		 LEFT JOIN pools ap ON m.meeting_admin_pool_id = ap.id
 		 WHERE m.id = :meetingId
 		   AND NOW() >= m.start_date
 		   AND NOW() <= m.end_date
@@ -530,13 +530,13 @@ export async function joinMeetingAsWatcher(
 		endDate: meetingRow.end_date,
 		quorumVotingPoolId: meetingRow.quorum_voting_pool_id,
 		watcherPoolId: meetingRow.watcher_pool_id,
-		adminPoolId: meetingRow.admin_pool_id,
+		meetingAdminPoolId: meetingRow.meeting_admin_pool_id,
 		quorumCalledAt: meetingRow.quorum_called_at,
 		createdAt: meetingRow.created_at,
 		updatedAt: meetingRow.updated_at,
 		quorumVotingPoolName: meetingRow.quorum_pool_name,
 		watcherPoolName: meetingRow.watcher_pool_name,
-		adminPoolName: meetingRow.admin_pool_name,
+		meetingAdminPoolName: meetingRow.meeting_admin_pool_name,
 	};
 
 	return { participant, meeting };
@@ -565,12 +565,12 @@ export async function getJoinableMeetingsForAdmin(
 	}>(
 		`SELECT DISTINCT m.id, m.name, m.description, m.start_date, m.end_date, p.pool_name
 		 FROM meetings m
-		 INNER JOIN pools p ON m.admin_pool_id = p.id
-		 INNER JOIN user_pools up ON up.pool_id = m.admin_pool_id
+		 INNER JOIN pools p ON m.meeting_admin_pool_id = p.id
+		 INNER JOIN user_pools up ON up.pool_id = m.meeting_admin_pool_id
 		 WHERE up.user_id = :userId
 		   AND NOW() >= m.start_date
 		   AND NOW() <= m.end_date
-		   AND m.admin_pool_id IS NOT NULL
+		   AND m.meeting_admin_pool_id IS NOT NULL
 		 ORDER BY m.start_date ASC`,
 		{ userId },
 	);
@@ -638,26 +638,26 @@ export async function joinMeetingAsAdmin(
 		? `SELECT m.*,
 		        qp.pool_name as quorum_pool_name,
 		        wp.pool_name as watcher_pool_name,
-		        ap.pool_name as admin_pool_name
+		        ap.pool_name as meeting_admin_pool_name
 		 FROM meetings m
 		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
 		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
-		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
+		 LEFT JOIN pools ap ON m.meeting_admin_pool_id = ap.id
 		 WHERE m.id = :meetingId
 		   AND NOW() >= m.start_date
 		   AND NOW() <= m.end_date`
 		: `SELECT m.*,
 		        qp.pool_name as quorum_pool_name,
 		        wp.pool_name as watcher_pool_name,
-		        ap.pool_name as admin_pool_name
+		        ap.pool_name as meeting_admin_pool_name
 		 FROM meetings m
 		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
 		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
-		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
+		 LEFT JOIN pools ap ON m.meeting_admin_pool_id = ap.id
 		 WHERE m.id = :meetingId
 		   AND NOW() >= m.start_date
 		   AND NOW() <= m.end_date
-		   AND m.admin_pool_id IS NOT NULL`;
+		   AND m.meeting_admin_pool_id IS NOT NULL`;
 
 	const meetingResult = await db.query<{
 		id: number;
@@ -667,13 +667,13 @@ export async function joinMeetingAsAdmin(
 		end_date: Date;
 		quorum_voting_pool_id: number;
 		watcher_pool_id: number | null;
-		admin_pool_id: number | null;
+		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
 		created_at: Date;
 		updated_at: Date;
 		quorum_pool_name: string;
 		watcher_pool_name: string | null;
-		admin_pool_name: string | null;
+		meeting_admin_pool_name: string | null;
 	}>(meetingQuery, { meetingId });
 
 	if (meetingResult.rows.length === EMPTY_ARRAY_LENGTH) {
@@ -688,7 +688,7 @@ export async function joinMeetingAsAdmin(
 	if (!isGlobalAdmin) {
 		const poolCheck = await db.query<{ user_id: string }>(
 			`SELECT up.user_id FROM user_pools up
-			 INNER JOIN meetings m ON m.admin_pool_id = up.pool_id
+			 INNER JOIN meetings m ON m.meeting_admin_pool_id = up.pool_id
 			 WHERE m.id = :meetingId AND up.user_id = :userId`,
 			{ meetingId, userId },
 		);
@@ -731,13 +731,13 @@ export async function joinMeetingAsAdmin(
 		endDate: meetingRow.end_date,
 		quorumVotingPoolId: meetingRow.quorum_voting_pool_id,
 		watcherPoolId: meetingRow.watcher_pool_id,
-		adminPoolId: meetingRow.admin_pool_id,
+		meetingAdminPoolId: meetingRow.meeting_admin_pool_id,
 		quorumCalledAt: meetingRow.quorum_called_at,
 		createdAt: meetingRow.created_at,
 		updatedAt: meetingRow.updated_at,
 		quorumVotingPoolName: meetingRow.quorum_pool_name,
 		watcherPoolName: meetingRow.watcher_pool_name,
-		adminPoolName: meetingRow.admin_pool_name,
+		meetingAdminPoolName: meetingRow.meeting_admin_pool_name,
 	};
 
 	return { participant, meeting };
@@ -753,7 +753,7 @@ export async function isUserMeetingAdmin(
 ): Promise<boolean> {
 	const result = await db.query<{ user_id: string }>(
 		`SELECT up.user_id FROM user_pools up
-		 INNER JOIN meetings m ON m.admin_pool_id = up.pool_id
+		 INNER JOIN meetings m ON m.meeting_admin_pool_id = up.pool_id
 		 WHERE m.id = :meetingId AND up.user_id = :userId`,
 		{ meetingId, userId },
 	);

--- a/packages/server/src/services/meeting-service.ts
+++ b/packages/server/src/services/meeting-service.ts
@@ -14,12 +14,14 @@ import {
 	type MotionDetailedResults,
 	type MotionVoteStats,
 	type MotionWithPool,
+	type Pool,
 	type UpdateChoiceRequest,
 	type UpdateMeetingRequest,
 	type UpdateMotionRequest,
 	type UpdateMotionStatusRequest,
 } from "@mcdc-convention-voting/shared";
-import { db } from "../database/db.js";
+import { db, withTransaction } from "../database/db.js";
+import { createPool, generatePoolKeyFromMeetingName } from "./pool-service.js";
 
 // Array index constants
 const FIRST_ROW = 0;
@@ -69,38 +71,62 @@ async function verifyPoolExists(
 	}
 }
 
+// Pool name suffixes for auto-created pools
+const WATCHER_POOL_SUFFIX = "watchers";
+const MEETING_ADMIN_POOL_SUFFIX = "meeting-admins";
+
 // ============================================================================
 // Meeting Functions
 // ============================================================================
 
 /**
+ * Auto-create watcher and meeting admin pools for a new meeting
+ */
+async function autoCreateMeetingPools(meetingName: string): Promise<{
+	watcherPool: Pool;
+	meetingAdminPool: Pool;
+}> {
+	// Generate unique pool keys
+	const watcherPoolKey = await generatePoolKeyFromMeetingName(
+		meetingName,
+		WATCHER_POOL_SUFFIX,
+	);
+	const meetingAdminPoolKey = await generatePoolKeyFromMeetingName(
+		meetingName,
+		MEETING_ADMIN_POOL_SUFFIX,
+	);
+
+	// Create watcher pool
+	const watcherPool = await createPool({
+		poolKey: watcherPoolKey,
+		poolName: `${meetingName} - Watchers`,
+		description: `Watchers for meeting: ${meetingName}`,
+	});
+
+	// Create meeting admin pool
+	const meetingAdminPool = await createPool({
+		poolKey: meetingAdminPoolKey,
+		poolName: `${meetingName} - Meeting Admins`,
+		description: `Meeting administrators for: ${meetingName}`,
+	});
+
+	return { watcherPool, meetingAdminPool };
+}
+
+/**
  * Create a new meeting
+ * Auto-creates watcher and meeting admin pools
  */
 export async function createMeeting(
 	request: CreateMeetingRequest,
 ): Promise<Meeting> {
-	const {
-		name,
-		description,
-		startDate,
-		endDate,
-		quorumVotingPoolId,
-		watcherPoolId,
-		adminPoolId,
-	} = request;
+	const { name, description, startDate, endDate, quorumVotingPoolId } = request;
 
 	// Verify quorum pool exists
 	await verifyPoolExists(quorumVotingPoolId, "Pool");
 
-	// Verify watcher pool exists if specified
-	if (watcherPoolId !== undefined && watcherPoolId !== null) {
-		await verifyPoolExists(watcherPoolId, "Watcher pool");
-	}
-
-	// Verify admin pool exists if specified
-	if (adminPoolId !== undefined && adminPoolId !== null) {
-		await verifyPoolExists(adminPoolId, "Admin pool");
-	}
+	// Auto-create watcher and meeting admin pools
+	const { watcherPool, meetingAdminPool } = await autoCreateMeetingPools(name);
 
 	const result = await db.query<{
 		id: number;
@@ -110,13 +136,13 @@ export async function createMeeting(
 		end_date: Date;
 		quorum_voting_pool_id: number;
 		watcher_pool_id: number | null;
-		admin_pool_id: number | null;
+		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
 		created_at: Date;
 		updated_at: Date;
 	}>(
-		`INSERT INTO meetings (name, description, start_date, end_date, quorum_voting_pool_id, watcher_pool_id, admin_pool_id)
-		 VALUES (:name, :description, :startDate, :endDate, :quorumVotingPoolId, :watcherPoolId, :adminPoolId)
+		`INSERT INTO meetings (name, description, start_date, end_date, quorum_voting_pool_id, watcher_pool_id, meeting_admin_pool_id)
+		 VALUES (:name, :description, :startDate, :endDate, :quorumVotingPoolId, :watcherPoolId, :meetingAdminPoolId)
 		 RETURNING *`,
 		{
 			name,
@@ -124,14 +150,22 @@ export async function createMeeting(
 			startDate,
 			endDate,
 			quorumVotingPoolId,
-			watcherPoolId: watcherPoolId ?? null,
-			adminPoolId: adminPoolId ?? null,
+			watcherPoolId: watcherPool.id,
+			meetingAdminPoolId: meetingAdminPool.id,
 		},
 	);
 
 	const {
 		rows: [row],
 	} = result;
+
+	// Add quorum pool to voter pools junction table
+	await db.query(
+		`INSERT INTO meeting_voter_pools (meeting_id, pool_id)
+		 VALUES (:meetingId, :poolId)`,
+		{ meetingId: row.id, poolId: quorumVotingPoolId },
+	);
+
 	return {
 		id: row.id,
 		name: row.name,
@@ -140,10 +174,11 @@ export async function createMeeting(
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
 		watcherPoolId: row.watcher_pool_id,
-		adminPoolId: row.admin_pool_id,
+		meetingAdminPoolId: row.meeting_admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
+		voterPoolIds: [quorumVotingPoolId],
 	};
 }
 
@@ -161,22 +196,22 @@ export async function getMeetingById(
 		end_date: Date;
 		quorum_voting_pool_id: number;
 		watcher_pool_id: number | null;
-		admin_pool_id: number | null;
+		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
 		created_at: Date;
 		updated_at: Date;
 		quorum_pool_name: string;
 		watcher_pool_name: string | null;
-		admin_pool_name: string | null;
+		meeting_admin_pool_name: string | null;
 	}>(
 		`SELECT m.*,
 		        qp.pool_name as quorum_pool_name,
 		        wp.pool_name as watcher_pool_name,
-		        ap.pool_name as admin_pool_name
+		        ap.pool_name as meeting_admin_pool_name
 		 FROM meetings m
 		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
 		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
-		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
+		 LEFT JOIN pools ap ON m.meeting_admin_pool_id = ap.id
 		 WHERE m.id = :meetingId`,
 		{ meetingId },
 	);
@@ -188,6 +223,10 @@ export async function getMeetingById(
 	const {
 		rows: [row],
 	} = result;
+
+	// Get voter pool IDs
+	const voterPoolIds = await getVoterPoolsForMeeting(meetingId);
+
 	return {
 		id: row.id,
 		name: row.name,
@@ -196,13 +235,14 @@ export async function getMeetingById(
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
 		watcherPoolId: row.watcher_pool_id,
-		adminPoolId: row.admin_pool_id,
+		meetingAdminPoolId: row.meeting_admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 		quorumVotingPoolName: row.quorum_pool_name,
 		watcherPoolName: row.watcher_pool_name,
-		adminPoolName: row.admin_pool_name,
+		meetingAdminPoolName: row.meeting_admin_pool_name,
+		voterPoolIds,
 	};
 }
 
@@ -230,22 +270,22 @@ export async function listMeetings(
 		end_date: Date;
 		quorum_voting_pool_id: number;
 		watcher_pool_id: number | null;
-		admin_pool_id: number | null;
+		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
 		created_at: Date;
 		updated_at: Date;
 		quorum_pool_name: string;
 		watcher_pool_name: string | null;
-		admin_pool_name: string | null;
+		meeting_admin_pool_name: string | null;
 	}>(
 		`SELECT m.*,
 		        qp.pool_name as quorum_pool_name,
 		        wp.pool_name as watcher_pool_name,
-		        ap.pool_name as admin_pool_name
+		        ap.pool_name as meeting_admin_pool_name
 		 FROM meetings m
 		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
 		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
-		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
+		 LEFT JOIN pools ap ON m.meeting_admin_pool_id = ap.id
 		 ORDER BY m.start_date DESC
 		 LIMIT :limit OFFSET :offset`,
 		{ limit, offset },
@@ -259,13 +299,13 @@ export async function listMeetings(
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
 		watcherPoolId: row.watcher_pool_id,
-		adminPoolId: row.admin_pool_id,
+		meetingAdminPoolId: row.meeting_admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 		quorumVotingPoolName: row.quorum_pool_name,
 		watcherPoolName: row.watcher_pool_name,
-		adminPoolName: row.admin_pool_name,
+		meetingAdminPoolName: row.meeting_admin_pool_name,
 	}));
 
 	return { meetings, total };
@@ -285,7 +325,7 @@ export async function listMeetingsForMeetingAdmin(
 	// Get total count for meetings where user is in admin pool
 	const countResult = await db.query<{ count: string }>(
 		`SELECT COUNT(*) as count FROM meetings m
-		 INNER JOIN user_pools up ON m.admin_pool_id = up.pool_id
+		 INNER JOIN user_pools up ON m.meeting_admin_pool_id = up.pool_id
 		 WHERE up.user_id = :userId`,
 		{ userId },
 	);
@@ -300,23 +340,23 @@ export async function listMeetingsForMeetingAdmin(
 		end_date: Date;
 		quorum_voting_pool_id: number;
 		watcher_pool_id: number | null;
-		admin_pool_id: number | null;
+		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
 		created_at: Date;
 		updated_at: Date;
 		quorum_pool_name: string;
 		watcher_pool_name: string | null;
-		admin_pool_name: string | null;
+		meeting_admin_pool_name: string | null;
 	}>(
 		`SELECT m.*,
 		        qp.pool_name as quorum_pool_name,
 		        wp.pool_name as watcher_pool_name,
-		        ap.pool_name as admin_pool_name
+		        ap.pool_name as meeting_admin_pool_name
 		 FROM meetings m
 		 INNER JOIN pools qp ON m.quorum_voting_pool_id = qp.id
 		 LEFT JOIN pools wp ON m.watcher_pool_id = wp.id
-		 LEFT JOIN pools ap ON m.admin_pool_id = ap.id
-		 INNER JOIN user_pools up ON m.admin_pool_id = up.pool_id
+		 LEFT JOIN pools ap ON m.meeting_admin_pool_id = ap.id
+		 INNER JOIN user_pools up ON m.meeting_admin_pool_id = up.pool_id
 		 WHERE up.user_id = :userId
 		 ORDER BY m.start_date DESC
 		 LIMIT :limit OFFSET :offset`,
@@ -331,13 +371,13 @@ export async function listMeetingsForMeetingAdmin(
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
 		watcherPoolId: row.watcher_pool_id,
-		adminPoolId: row.admin_pool_id,
+		meetingAdminPoolId: row.meeting_admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 		quorumVotingPoolName: row.quorum_pool_name,
 		watcherPoolName: row.watcher_pool_name,
-		adminPoolName: row.admin_pool_name,
+		meetingAdminPoolName: row.meeting_admin_pool_name,
 	}));
 
 	return { meetings, total };
@@ -356,7 +396,7 @@ async function buildMeetingUpdateClauses(
 		endDate,
 		quorumVotingPoolId,
 		watcherPoolId,
-		adminPoolId,
+		meetingAdminPoolId,
 	} = updates;
 
 	const setClauses: string[] = [];
@@ -396,12 +436,12 @@ async function buildMeetingUpdateClauses(
 		values.watcherPoolId = watcherPoolId;
 	}
 
-	if (adminPoolId !== undefined) {
-		if (adminPoolId !== null) {
-			await verifyPoolExists(adminPoolId, "Admin pool");
+	if (meetingAdminPoolId !== undefined) {
+		if (meetingAdminPoolId !== null) {
+			await verifyPoolExists(meetingAdminPoolId, "Admin pool");
 		}
-		setClauses.push(`admin_pool_id = :adminPoolId`);
-		values.adminPoolId = adminPoolId;
+		setClauses.push(`meeting_admin_pool_id = :meetingAdminPoolId`);
+		values.meetingAdminPoolId = meetingAdminPoolId;
 	}
 
 	return { setClauses, values };
@@ -432,7 +472,7 @@ export async function updateMeeting(
 		end_date: Date;
 		quorum_voting_pool_id: number;
 		watcher_pool_id: number | null;
-		admin_pool_id: number | null;
+		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
 		created_at: Date;
 		updated_at: Date;
@@ -459,7 +499,7 @@ export async function updateMeeting(
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
 		watcherPoolId: row.watcher_pool_id,
-		adminPoolId: row.admin_pool_id,
+		meetingAdminPoolId: row.meeting_admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
@@ -478,6 +518,148 @@ export async function deleteMeeting(meetingId: number): Promise<void> {
 	if (result.rows.length === EMPTY_ARRAY_LENGTH) {
 		throw new Error(`Meeting with ID ${String(meetingId)} not found`);
 	}
+}
+
+// ============================================================================
+// Voter Pool Junction Table Functions
+// ============================================================================
+
+/**
+ * Get voter pool IDs for a meeting
+ */
+export async function getVoterPoolsForMeeting(
+	meetingId: number,
+): Promise<number[]> {
+	const result = await db.query<{ pool_id: number }>(
+		`SELECT pool_id FROM meeting_voter_pools
+		 WHERE meeting_id = :meetingId
+		 ORDER BY created_at ASC`,
+		{ meetingId },
+	);
+
+	return result.rows.map((row) => row.pool_id);
+}
+
+/**
+ * Add a voter pool to a meeting
+ */
+export async function addVoterPoolToMeeting(
+	meetingId: number,
+	poolId: number,
+): Promise<void> {
+	// Verify pool exists
+	await verifyPoolExists(poolId, "Voter pool");
+
+	await db.query(
+		`INSERT INTO meeting_voter_pools (meeting_id, pool_id)
+		 VALUES (:meetingId, :poolId)
+		 ON CONFLICT (meeting_id, pool_id) DO NOTHING`,
+		{ meetingId, poolId },
+	);
+}
+
+/**
+ * Remove a voter pool from a meeting
+ * Cannot remove the quorum voting pool
+ */
+export async function removeVoterPoolFromMeeting(
+	meetingId: number,
+	poolId: number,
+): Promise<void> {
+	// Check if this is the quorum pool
+	const meetingResult = await db.query<{ quorum_voting_pool_id: number }>(
+		"SELECT quorum_voting_pool_id FROM meetings WHERE id = :meetingId",
+		{ meetingId },
+	);
+
+	if (meetingResult.rows.length === EMPTY_ARRAY_LENGTH) {
+		throw new Error(`Meeting with ID ${String(meetingId)} not found`);
+	}
+
+	const {
+		rows: [{ quorum_voting_pool_id: quorumPoolId }],
+	} = meetingResult;
+
+	if (poolId === quorumPoolId) {
+		throw new Error("Cannot remove the quorum voting pool from voter pools");
+	}
+
+	await db.query(
+		`DELETE FROM meeting_voter_pools
+		 WHERE meeting_id = :meetingId AND pool_id = :poolId`,
+		{ meetingId, poolId },
+	);
+}
+
+/**
+ * Set all voter pools for a meeting
+ * The quorum pool is always included regardless of input
+ */
+export async function setVoterPoolsForMeeting(
+	meetingId: number,
+	poolIds: number[],
+): Promise<number[]> {
+	// Get the quorum pool ID
+	const meetingResult = await db.query<{ quorum_voting_pool_id: number }>(
+		"SELECT quorum_voting_pool_id FROM meetings WHERE id = :meetingId",
+		{ meetingId },
+	);
+
+	if (meetingResult.rows.length === EMPTY_ARRAY_LENGTH) {
+		throw new Error(`Meeting with ID ${String(meetingId)} not found`);
+	}
+
+	const {
+		rows: [{ quorum_voting_pool_id: quorumPoolId }],
+	} = meetingResult;
+
+	// Ensure quorum pool is always included
+	const finalPoolIds = [...new Set([quorumPoolId, ...poolIds])];
+
+	// Verify all pools exist
+	for (const poolId of finalPoolIds) {
+		// eslint-disable-next-line no-await-in-loop -- Sequential verification required
+		await verifyPoolExists(poolId, "Voter pool");
+	}
+
+	return await withTransaction(async (tx) => {
+		// Delete existing voter pool associations
+		await tx.query(
+			"DELETE FROM meeting_voter_pools WHERE meeting_id = :meetingId",
+			{ meetingId },
+		);
+
+		// Insert new associations
+		for (const poolId of finalPoolIds) {
+			// eslint-disable-next-line no-await-in-loop -- Sequential inserts in transaction
+			await tx.query(
+				`INSERT INTO meeting_voter_pools (meeting_id, pool_id)
+				 VALUES (:meetingId, :poolId)`,
+				{ meetingId, poolId },
+			);
+		}
+
+		return finalPoolIds;
+	});
+}
+
+/**
+ * Check if a user is in any voter pool for a meeting
+ */
+export async function isUserInMeetingVoterPools(
+	userId: string,
+	meetingId: number,
+): Promise<boolean> {
+	const result = await db.query<{ exists: boolean }>(
+		`SELECT EXISTS(
+			SELECT 1 FROM meeting_voter_pools mvp
+			INNER JOIN user_pools up ON mvp.pool_id = up.pool_id
+			WHERE mvp.meeting_id = :meetingId AND up.user_id = :userId
+		) as exists`,
+		{ meetingId, userId },
+	);
+
+	return result.rows[FIRST_ROW].exists;
 }
 
 /**

--- a/packages/server/src/services/pool-service.ts
+++ b/packages/server/src/services/pool-service.ts
@@ -31,6 +31,41 @@ export async function poolKeyExists(poolKey: string): Promise<boolean> {
 	return result.rows[FIRST_ROW].exists;
 }
 
+// Pool key generation constants
+const INITIAL_COUNTER = 1;
+const COUNTER_INCREMENT = 1;
+
+/**
+ * Generate a unique pool key from a meeting name
+ * Slugifies the name and adds suffix, handling conflicts
+ *
+ * @param meetingName - The meeting name to slugify
+ * @param suffix - Suffix to add (e.g., "watchers", "meeting-admins")
+ * @returns A unique pool key
+ */
+export async function generatePoolKeyFromMeetingName(
+	meetingName: string,
+	suffix: string,
+): Promise<string> {
+	// Slugify: lowercase, replace spaces/special chars with hyphens, trim leading/trailing hyphens
+	const slug = meetingName
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/(?:^-|-$)/g, "");
+
+	let poolKey = `${slug}-${suffix}`;
+	let counter = INITIAL_COUNTER;
+
+	// Check for conflicts and increment counter if needed
+	// eslint-disable-next-line no-await-in-loop -- Sequential uniqueness check required
+	while (await poolKeyExists(poolKey)) {
+		counter += COUNTER_INCREMENT;
+		poolKey = `${slug}-${suffix}-${String(counter)}`;
+	}
+
+	return poolKey;
+}
+
 /**
  * Get pool by ID
  */
@@ -227,86 +262,145 @@ export async function listPools(
 }
 
 /**
+ * Result of updating a pool, including resolved pending assignments
+ */
+export interface UpdatePoolResult {
+	pool: Pool;
+	resolvedUsers: number;
+}
+
+/**
  * Update pool details
+ *
+ * When the pool key is changed, this function automatically resolves any
+ * pending pool assignments that match either the OLD or NEW key:
+ * - Users with pending assignments for the NEW key are added to this pool
+ * - Users with pending assignments for the OLD key are added to this pool
+ * - All resolved pending records are deleted
  */
 export async function updatePool(
 	poolId: number,
 	updates: UpdatePoolRequest,
-): Promise<Pool> {
-	const { poolKey, poolName, description } = updates;
+): Promise<UpdatePoolResult> {
+	const { poolKey: newPoolKey, poolName, description } = updates;
 
-	// Build dynamic update query
-	const setClauses: string[] = [];
-	const values: Record<string, unknown> = { poolId };
+	return await withTransaction(async (tx) => {
+		// Get current pool data before updating
+		const currentPoolResult = await tx.query<{
+			id: number;
+			pool_key: string;
+		}>("SELECT id, pool_key FROM pools WHERE id = :poolId", { poolId });
 
-	if (poolKey !== undefined) {
-		// Check if new pool key already exists
-		if (await poolKeyExists(poolKey)) {
-			const existingPool = await db.query<{ id: number }>(
-				"SELECT id FROM pools WHERE pool_key = :poolKey",
-				{ poolKey },
-			);
-			// Only throw error if it's a different pool
-			const {
-				rows: [existingRow],
-			} = existingPool;
-			if (existingRow.id !== poolId) {
-				throw new Error(`Pool key ${poolKey} already exists`);
-			}
+		if (currentPoolResult.rows.length === EMPTY_ARRAY_LENGTH) {
+			throw new Error(`Pool with ID ${poolId} not found`);
 		}
-		setClauses.push(`pool_key = :poolKey`);
-		values.poolKey = poolKey;
-	}
 
-	if (poolName !== undefined) {
-		setClauses.push(`pool_name = :poolName`);
-		values.poolName = poolName;
-	}
+		const {
+			rows: [{ pool_key: oldPoolKey }],
+		} = currentPoolResult;
 
-	if (description !== undefined) {
-		setClauses.push(`description = :description`);
-		values.description = description;
-	}
+		// Build dynamic update query
+		const setClauses: string[] = [];
+		const values: Record<string, unknown> = { poolId };
 
-	if (setClauses.length === EMPTY_ARRAY_LENGTH) {
-		throw new Error("No fields to update");
-	}
+		if (newPoolKey !== undefined) {
+			// Check if new pool key already exists (on a different pool)
+			const existingPool = await tx.query<{ id: number }>(
+				"SELECT id FROM pools WHERE pool_key = :newPoolKey AND id != :poolId",
+				{ newPoolKey, poolId },
+			);
+			if (existingPool.rows.length > EMPTY_ARRAY_LENGTH) {
+				throw new Error(`Pool key ${newPoolKey} already exists`);
+			}
+			setClauses.push(`pool_key = :newPoolKey`);
+			values.newPoolKey = newPoolKey;
+		}
 
-	// Add updated_at
-	setClauses.push(`updated_at = NOW()`);
+		if (poolName !== undefined) {
+			setClauses.push(`pool_name = :poolName`);
+			values.poolName = poolName;
+		}
 
-	const result = await db.query<{
-		id: number;
-		pool_key: string;
-		pool_name: string;
-		description: string | null;
-		is_disabled: boolean;
-		created_at: Date;
-		updated_at: Date;
-	}>(
-		`UPDATE pools
-     SET ${setClauses.join(", ")}
-     WHERE id = :poolId
-     RETURNING *`,
-		values,
-	);
+		if (description !== undefined) {
+			setClauses.push(`description = :description`);
+			values.description = description;
+		}
 
-	if (result.rows.length === EMPTY_ARRAY_LENGTH) {
-		throw new Error(`Pool with ID ${poolId} not found`);
-	}
+		if (setClauses.length === EMPTY_ARRAY_LENGTH) {
+			throw new Error("No fields to update");
+		}
 
-	const {
-		rows: [row],
-	} = result;
-	return {
-		id: row.id,
-		poolKey: row.pool_key,
-		poolName: row.pool_name,
-		description: row.description,
-		isDisabled: row.is_disabled,
-		createdAt: row.created_at,
-		updatedAt: row.updated_at,
-	};
+		// Add updated_at
+		setClauses.push(`updated_at = NOW()`);
+
+		// Update the pool
+		const result = await tx.query<{
+			id: number;
+			pool_key: string;
+			pool_name: string;
+			description: string | null;
+			is_disabled: boolean;
+			created_at: Date;
+			updated_at: Date;
+		}>(
+			`UPDATE pools
+       SET ${setClauses.join(", ")}
+       WHERE id = :poolId
+       RETURNING *`,
+			values,
+		);
+
+		const {
+			rows: [row],
+		} = result;
+		const pool: Pool = {
+			id: row.id,
+			poolKey: row.pool_key,
+			poolName: row.pool_name,
+			description: row.description,
+			isDisabled: row.is_disabled,
+			createdAt: row.created_at,
+			updatedAt: row.updated_at,
+		};
+
+		// Resolve pending assignments if pool key was changed
+		if (newPoolKey === undefined || newPoolKey === oldPoolKey) {
+			return { pool, resolvedUsers: 0 };
+		}
+
+		// Collect pool keys to resolve: both OLD and NEW keys
+		const keysToResolve = [oldPoolKey, newPoolKey];
+
+		// Find all users with pending assignments for either key
+		const pendingUsersResult = await tx.query<{ user_id: string }>(
+			`SELECT DISTINCT user_id FROM pending_pool_keys
+       WHERE pool_key = ANY(:keysToResolve)`,
+			{ keysToResolve },
+		);
+
+		// Add each user to the pool
+		for (const { user_id: userId } of pendingUsersResult.rows) {
+			// eslint-disable-next-line no-await-in-loop -- Sequential within transaction
+			await tx.query(
+				`INSERT INTO user_pools (pool_id, user_id)
+         VALUES (:poolId, :userId)
+         ON CONFLICT (pool_id, user_id) DO NOTHING`,
+				{ poolId, userId },
+			);
+		}
+
+		const {
+			rows: { length: resolvedUsers },
+		} = pendingUsersResult;
+
+		// Delete all resolved pending records
+		await tx.query(
+			`DELETE FROM pending_pool_keys WHERE pool_key = ANY(:keysToResolve)`,
+			{ keysToResolve },
+		);
+
+		return { pool, resolvedUsers };
+	});
 }
 
 /**
@@ -413,12 +507,13 @@ export async function getUsersInPool(
 		last_name: string;
 		is_admin: boolean;
 		is_watcher: boolean;
+		is_meeting_admin: boolean;
 		is_disabled: boolean;
 		created_at: Date;
 		updated_at: Date;
 	}>(
 		`SELECT u.id, u.username, u.voter_id, u.first_name, u.last_name,
-            u.is_admin, u.is_watcher, u.is_disabled, u.created_at, u.updated_at
+            u.is_admin, u.is_watcher, u.is_meeting_admin, u.is_disabled, u.created_at, u.updated_at
      FROM users u
      INNER JOIN user_pools up ON u.id = up.user_id
      WHERE up.pool_id = :poolId
@@ -435,6 +530,7 @@ export async function getUsersInPool(
 		lastName: row.last_name,
 		isAdmin: row.is_admin,
 		isWatcher: row.is_watcher,
+		isMeetingAdmin: row.is_meeting_admin,
 		isDisabled: row.is_disabled,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,

--- a/packages/server/src/services/user-service.ts
+++ b/packages/server/src/services/user-service.ts
@@ -103,13 +103,14 @@ export async function createUser(request: CreateUserRequest): Promise<User> {
 		last_name: string;
 		is_admin: boolean;
 		is_watcher: boolean;
+		is_meeting_admin: boolean;
 		is_disabled: boolean;
 		created_at: Date;
 		updated_at: Date;
 	}>(
 		`INSERT INTO users (username, voter_id, first_name, last_name, password_hash, is_admin, is_watcher)
      VALUES (:username, :voterId, :firstName, :lastName, NULL, :isAdmin, :isWatcher)
-     RETURNING id, username, voter_id, first_name, last_name, is_admin, is_watcher, is_disabled, created_at, updated_at`,
+     RETURNING id, username, voter_id, first_name, last_name, is_admin, is_watcher, is_meeting_admin, is_disabled, created_at, updated_at`,
 		{
 			username: finalUsername,
 			voterId,
@@ -131,6 +132,7 @@ export async function createUser(request: CreateUserRequest): Promise<User> {
 		lastName: row.last_name,
 		isAdmin: row.is_admin,
 		isWatcher: row.is_watcher,
+		isMeetingAdmin: row.is_meeting_admin,
 		isDisabled: row.is_disabled,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
@@ -185,6 +187,7 @@ export async function upsertUser(request: CreateUserRequest): Promise<User> {
 		last_name: string;
 		is_admin: boolean;
 		is_watcher: boolean;
+		is_meeting_admin: boolean;
 		is_disabled: boolean;
 		created_at: Date;
 		updated_at: Date;
@@ -198,7 +201,7 @@ export async function upsertUser(request: CreateUserRequest): Promise<User> {
        is_watcher = EXCLUDED.is_watcher,
        is_disabled = EXCLUDED.is_disabled,
        updated_at = NOW()
-     RETURNING id, username, voter_id, first_name, last_name, is_admin, is_watcher, is_disabled, created_at, updated_at`,
+     RETURNING id, username, voter_id, first_name, last_name, is_admin, is_watcher, is_meeting_admin, is_disabled, created_at, updated_at`,
 		{
 			username: generatedUsername,
 			voterId,
@@ -221,6 +224,7 @@ export async function upsertUser(request: CreateUserRequest): Promise<User> {
 		lastName: row.last_name,
 		isAdmin: row.is_admin,
 		isWatcher: row.is_watcher,
+		isMeetingAdmin: row.is_meeting_admin,
 		isDisabled: row.is_disabled,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
@@ -450,11 +454,12 @@ export async function getUserById(userId: string): Promise<User | null> {
 		last_name: string;
 		is_admin: boolean;
 		is_watcher: boolean;
+		is_meeting_admin: boolean;
 		is_disabled: boolean;
 		created_at: Date;
 		updated_at: Date;
 	}>(
-		"SELECT id, username, voter_id, first_name, last_name, is_admin, is_watcher, is_disabled, created_at, updated_at FROM users WHERE id = :userId",
+		"SELECT id, username, voter_id, first_name, last_name, is_admin, is_watcher, is_meeting_admin, is_disabled, created_at, updated_at FROM users WHERE id = :userId",
 		{ userId },
 	);
 
@@ -473,6 +478,7 @@ export async function getUserById(userId: string): Promise<User | null> {
 		lastName: row.last_name,
 		isAdmin: row.is_admin,
 		isWatcher: row.is_watcher,
+		isMeetingAdmin: row.is_meeting_admin,
 		isDisabled: row.is_disabled,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
@@ -553,6 +559,7 @@ export async function listUsers(
 		last_name: string;
 		is_admin: boolean;
 		is_watcher: boolean;
+		is_meeting_admin: boolean;
 		is_disabled: boolean;
 		created_at: Date;
 		updated_at: Date;
@@ -560,7 +567,7 @@ export async function listUsers(
 	}>(
 		`SELECT
        u.id, u.username, u.voter_id, u.first_name, u.last_name,
-       u.is_admin, u.is_watcher, u.is_disabled, u.created_at, u.updated_at,
+       u.is_admin, u.is_watcher, u.is_meeting_admin, u.is_disabled, u.created_at, u.updated_at,
        array_agg(p.pool_name ORDER BY p.pool_name) FILTER (WHERE p.pool_name IS NOT NULL) as pool_names
      FROM users u
      ${poolJoin}
@@ -581,6 +588,7 @@ export async function listUsers(
 		lastName: row.last_name,
 		isAdmin: row.is_admin,
 		isWatcher: row.is_watcher,
+		isMeetingAdmin: row.is_meeting_admin,
 		isDisabled: row.is_disabled,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
@@ -665,6 +673,7 @@ export async function updateUser(
 			last_name: string;
 			is_admin: boolean;
 			is_watcher: boolean;
+			is_meeting_admin: boolean;
 			is_disabled: boolean;
 			created_at: Date;
 			updated_at: Date;
@@ -672,7 +681,7 @@ export async function updateUser(
 			`UPDATE users
        SET ${setClauses.join(", ")}
        WHERE id = :userId
-       RETURNING id, username, voter_id, first_name, last_name, is_admin, is_watcher, is_disabled, created_at, updated_at`,
+       RETURNING id, username, voter_id, first_name, last_name, is_admin, is_watcher, is_meeting_admin, is_disabled, created_at, updated_at`,
 			values,
 		);
 
@@ -691,6 +700,7 @@ export async function updateUser(
 			lastName: row.last_name,
 			isAdmin: row.is_admin,
 			isWatcher: row.is_watcher,
+			isMeetingAdmin: row.is_meeting_admin,
 			isDisabled: row.is_disabled,
 			createdAt: row.created_at,
 			updatedAt: row.updated_at,
@@ -724,6 +734,7 @@ export async function disableUser(userId: string): Promise<User> {
 		last_name: string;
 		is_admin: boolean;
 		is_watcher: boolean;
+		is_meeting_admin: boolean;
 		is_disabled: boolean;
 		created_at: Date;
 		updated_at: Date;
@@ -731,7 +742,7 @@ export async function disableUser(userId: string): Promise<User> {
 		`UPDATE users
      SET is_disabled = TRUE, updated_at = NOW()
      WHERE id = :userId
-     RETURNING id, username, voter_id, first_name, last_name, is_admin, is_watcher, is_disabled, created_at, updated_at`,
+     RETURNING id, username, voter_id, first_name, last_name, is_admin, is_watcher, is_meeting_admin, is_disabled, created_at, updated_at`,
 		{ userId },
 	);
 
@@ -750,6 +761,7 @@ export async function disableUser(userId: string): Promise<User> {
 		lastName: row.last_name,
 		isAdmin: row.is_admin,
 		isWatcher: row.is_watcher,
+		isMeetingAdmin: row.is_meeting_admin,
 		isDisabled: row.is_disabled,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
@@ -768,6 +780,7 @@ export async function enableUser(userId: string): Promise<User> {
 		last_name: string;
 		is_admin: boolean;
 		is_watcher: boolean;
+		is_meeting_admin: boolean;
 		is_disabled: boolean;
 		created_at: Date;
 		updated_at: Date;
@@ -775,7 +788,7 @@ export async function enableUser(userId: string): Promise<User> {
 		`UPDATE users
      SET is_disabled = FALSE, updated_at = NOW()
      WHERE id = :userId
-     RETURNING id, username, voter_id, first_name, last_name, is_admin, is_watcher, is_disabled, created_at, updated_at`,
+     RETURNING id, username, voter_id, first_name, last_name, is_admin, is_watcher, is_meeting_admin, is_disabled, created_at, updated_at`,
 		{ userId },
 	);
 
@@ -794,6 +807,7 @@ export async function enableUser(userId: string): Promise<User> {
 		lastName: row.last_name,
 		isAdmin: row.is_admin,
 		isWatcher: row.is_watcher,
+		isMeetingAdmin: row.is_meeting_admin,
 		isDisabled: row.is_disabled,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
@@ -1038,11 +1052,12 @@ export async function listUsersByDateRange(
 		last_name: string;
 		is_admin: boolean;
 		is_watcher: boolean;
+		is_meeting_admin: boolean;
 		is_disabled: boolean;
 		created_at: Date;
 		updated_at: Date;
 	}>(
-		`SELECT id, username, voter_id, first_name, last_name, is_admin, is_watcher, is_disabled, created_at, updated_at
+		`SELECT id, username, voter_id, first_name, last_name, is_admin, is_watcher, is_meeting_admin, is_disabled, created_at, updated_at
      FROM users
      WHERE created_at >= :startDate AND created_at <= :endDate
      ORDER BY created_at DESC
@@ -1058,6 +1073,7 @@ export async function listUsersByDateRange(
 		lastName: row.last_name,
 		isAdmin: row.is_admin,
 		isWatcher: row.is_watcher,
+		isMeetingAdmin: row.is_meeting_admin,
 		isDisabled: row.is_disabled,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -14,12 +14,13 @@
  * - last_name: VARCHAR(255) NOT NULL
  * - is_admin: BOOLEAN NOT NULL DEFAULT FALSE
  * - is_watcher: BOOLEAN NOT NULL DEFAULT FALSE
+ * - is_meeting_admin: BOOLEAN NOT NULL DEFAULT FALSE
  * - is_disabled: BOOLEAN NOT NULL DEFAULT FALSE
  * - created_at: TIMESTAMP WITH TIME ZONE
  * - updated_at: TIMESTAMP WITH TIME ZONE
  *
- * Role exclusivity: A user can only be admin, watcher, or voter (neither flag set).
- * Database constraint prevents is_admin=TRUE AND is_watcher=TRUE.
+ * Role exclusivity: A user can only be admin, watcher, meeting_admin, or voter (all flags false).
+ * Database constraint ensures at most one of is_admin, is_watcher, is_meeting_admin is TRUE.
  *
  * Note: poolNames is computed from user_pools join, not stored in database
  *
@@ -33,6 +34,7 @@ export interface User {
 	lastName: string;
 	isAdmin: boolean;
 	isWatcher: boolean;
+	isMeetingAdmin: boolean;
 	isDisabled: boolean;
 	createdAt: Date;
 	updatedAt: Date;
@@ -78,7 +80,7 @@ export interface PaginatedResponse<T> {
  * User type/role values
  * Represents the exclusive role a user can have in the system
  */
-export type UserType = "voter" | "admin" | "watcher";
+export type UserType = "voter" | "admin" | "watcher" | "meeting_admin";
 
 /**
  * CSV row format for bulk user upload
@@ -87,7 +89,7 @@ export interface UserCSVRow {
 	voter_id: string;
 	first_name: string;
 	last_name: string;
-	user_type?: string; // Optional: 'voter' (default), 'admin', or 'watcher'
+	user_type?: string; // Optional: 'voter' (default), 'admin', 'watcher', or 'meeting_admin'
 	is_enabled: string; // Required: 'true', '1', 'false', or '0'
 	pool_key_1?: string;
 	pool_key_2?: string;
@@ -112,6 +114,7 @@ export interface CreateUserRequest {
 	poolKeys?: string[]; // Optional pool keys to associate with user
 	isAdmin?: boolean; // Optional, defaults to false
 	isWatcher?: boolean; // Optional, defaults to false
+	isMeetingAdmin?: boolean; // Optional, defaults to false
 	isDisabled?: boolean; // Optional, defaults to false
 }
 
@@ -351,10 +354,12 @@ export enum MotionStatus {
  * - end_date: TIMESTAMP WITH TIME ZONE NOT NULL
  * - quorum_voting_pool_id: INTEGER NOT NULL REFERENCES pools(id) ON DELETE RESTRICT
  * - watcher_pool_id: INTEGER REFERENCES pools(id) ON DELETE RESTRICT (nullable)
- * - admin_pool_id: INTEGER REFERENCES pools(id) ON DELETE RESTRICT (nullable)
+ * - meeting_admin_pool_id: INTEGER REFERENCES pools(id) ON DELETE RESTRICT (nullable)
  * - quorum_called_at: TIMESTAMP WITH TIME ZONE (nullable)
  * - created_at: TIMESTAMP WITH TIME ZONE
  * - updated_at: TIMESTAMP WITH TIME ZONE
+ *
+ * Note: voterPoolIds is populated from meeting_voter_pools junction table
  *
  * IMPORTANT: Keep this type in sync with database migrations
  */
@@ -366,10 +371,11 @@ export interface Meeting {
 	endDate: Date;
 	quorumVotingPoolId: number;
 	watcherPoolId: number | null;
-	adminPoolId: number | null;
+	meetingAdminPoolId: number | null;
 	quorumCalledAt: Date | null;
 	createdAt: Date;
 	updatedAt: Date;
+	voterPoolIds?: number[]; // Optional: populated from meeting_voter_pools junction
 }
 
 /**
@@ -378,7 +384,7 @@ export interface Meeting {
 export interface MeetingWithPool extends Meeting {
 	quorumVotingPoolName: string;
 	watcherPoolName: string | null;
-	adminPoolName: string | null;
+	meetingAdminPoolName: string | null;
 }
 
 /**
@@ -550,6 +556,7 @@ export interface Choice {
 
 /**
  * Request to create a meeting
+ * Note: watcherPoolId and meetingAdminPoolId are auto-created if not provided
  */
 export interface CreateMeetingRequest {
 	name: string;
@@ -557,8 +564,9 @@ export interface CreateMeetingRequest {
 	startDate: string; // ISO 8601 string
 	endDate: string; // ISO 8601 string
 	quorumVotingPoolId: number;
-	watcherPoolId?: number | null;
-	adminPoolId?: number | null;
+	voterPoolIds?: number[]; // Additional voter pools (quorum pool always included)
+	watcherPoolId?: number | null; // Auto-created if not provided
+	meetingAdminPoolId?: number | null; // Auto-created if not provided
 }
 
 /**
@@ -570,8 +578,9 @@ export interface UpdateMeetingRequest {
 	startDate?: string; // ISO 8601 string
 	endDate?: string; // ISO 8601 string
 	quorumVotingPoolId?: number;
+	voterPoolIds?: number[]; // Replace all voter pools
 	watcherPoolId?: number | null;
-	adminPoolId?: number | null;
+	meetingAdminPoolId?: number | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add meeting_voter_pools junction table for many-to-many relationship between meetings and voter pools
- Auto-create watcher and meeting admin pools when creating meetings
- Add voter pools checkbox interface to Edit Meeting page with inline pool creation
- Add Meeting Admin user role with role exclusivity constraint
- Rename "Admin Pool" to "Meeting Admin Pool" for consistency

## Changes

### Database
- New migration `0016-multiple-voter-pools.sql`:
  - `meeting_voter_pools` junction table
  - `is_meeting_admin` user flag
  - Role exclusivity constraint update
  - Migrate existing quorum pools to junction table

### Backend
- New API endpoints for voter pool management (`GET/PUT /admin/meetings/:id/voter-pools`)
- Auto-create watcher and meeting admin pools on meeting creation
- `setVoterPoolsForMeeting()` always includes quorum pool

### Frontend
- Voter pools checkbox grid in MeetingEdit.vue
- "+ Create New Pool" button with inline modal
- Quorum pool always checked and disabled
- Meeting Admin role option in UserCreate.vue

## Test plan

- [ ] Create a new meeting → verify watcher and meeting admin pools are auto-created
- [ ] Edit a meeting → verify voter pools checkbox grid shows all pools
- [ ] Quorum pool checkbox is checked and disabled
- [ ] Check/uncheck additional voter pools → save → reload → verify persistence
- [ ] Click "+ Create New Pool" → create a pool → verify it appears and is auto-checked
- [ ] Create a user with Meeting Admin role → verify role is saved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)