### PR TITLE
Add Motion Preview Feature (Issue #98)

### DIFF
--- a/packages/client/src/components/MotionPreviewModal.vue
+++ b/packages/client/src/components/MotionPreviewModal.vue
@@ -1,0 +1,420 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+interface Props {
+	motionName: string;
+	description: string | null;
+	selectionCount: number;
+	meetingName: string;
+	votingPoolName: string;
+	choices: Array<{
+		id?: number;
+		name: string;
+		sortOrder?: number;
+	}>;
+}
+
+const props = defineProps<Props>();
+
+defineEmits<{
+	close: [];
+}>();
+
+const DEFAULT_SORT_ORDER = 0;
+
+const sortedChoices = computed(() =>
+	[...props.choices].sort((a, b) => {
+		const orderA = a.sortOrder ?? DEFAULT_SORT_ORDER;
+		const orderB = b.sortOrder ?? DEFAULT_SORT_ORDER;
+		return orderA - orderB;
+	}),
+);
+</script>
+
+<template>
+	<div class="modal-overlay" @click="$emit('close')">
+		<div class="modal-container" @click.stop>
+			<!-- Phone frame with device chrome -->
+			<div class="phone-frame">
+				<!-- Device bezel (top notch area) -->
+				<div class="device-bezel">
+					<div class="notch"></div>
+				</div>
+
+				<!-- Preview disclaimer banner (sticky) -->
+				<div class="preview-banner">
+					⚠️ Preview Mode - No voting will be recorded
+				</div>
+
+				<!-- Scrollable content (replicates voter view) -->
+				<div class="phone-content">
+					<div class="motion-preview">
+						<div class="motion-header">
+							<h2>{{ motionName }}</h2>
+						</div>
+
+						<div v-if="description" class="motion-description">
+							<p>{{ description }}</p>
+						</div>
+
+						<div class="motion-info">
+							<div class="info-item">
+								<span class="info-label">Meeting</span>
+								<span class="info-value">{{ meetingName }}</span>
+							</div>
+							<div class="info-item">
+								<span class="info-label">Selections</span>
+								<span class="info-value">{{ selectionCount }}</span>
+							</div>
+							<div class="info-item">
+								<span class="info-label">Voting Pool</span>
+								<span class="info-value">{{ votingPoolName }}</span>
+							</div>
+						</div>
+
+						<div class="voting-section">
+							<h3>Cast Your Vote</h3>
+							<p class="vote-instructions">
+								Select up to {{ selectionCount }} choice(s), or choose to
+								abstain.
+							</p>
+
+							<!-- Choices list -->
+							<div class="choices-list">
+								<div
+									v-for="choice in sortedChoices"
+									:key="choice.id ?? choice.name"
+									class="choice-item disabled"
+								>
+									<span class="choice-checkbox"></span>
+									<span class="choice-name">{{ choice.name }}</span>
+								</div>
+							</div>
+
+							<!-- Abstain option -->
+							<div class="abstain-section">
+								<div class="choice-item abstain-item disabled">
+									<span class="choice-checkbox"></span>
+									<span class="choice-name">Abstain</span>
+								</div>
+								<p class="abstain-note">
+									Selecting Abstain will be treated the same as if you did not
+									vote on the motion, and will only impact the participation
+									records and statistics.
+								</p>
+							</div>
+
+							<!-- Submit button -->
+							<div class="submit-section">
+								<button
+									type="button"
+									class="btn btn-primary btn-large"
+									disabled
+								>
+									Submit Vote (Preview Only)
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<!-- Close button (outside phone frame) -->
+			<button type="button" class="close-button" @click="$emit('close')">
+				Close Preview
+			</button>
+		</div>
+	</div>
+</template>
+
+<style scoped>
+/* Modal overlay - full screen, dark background */
+.modal-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(0, 0, 0, 0.7);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 1000;
+	padding: 1rem;
+}
+
+/* Modal container */
+.modal-container {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	max-height: 90vh;
+}
+
+/* Phone frame - 375px width (standard iPhone width) */
+.phone-frame {
+	width: 375px;
+	max-width: 100vw;
+	max-height: 667px;
+	background-color: #1a1a1a;
+	border-radius: 36px;
+	padding: 12px;
+	box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+/* Device bezel (top notch area) */
+.device-bezel {
+	background-color: #1a1a1a;
+	height: 30px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 20px 20px 0 0;
+}
+
+/* Notch */
+.notch {
+	width: 150px;
+	height: 20px;
+	background-color: #000;
+	border-radius: 0 0 12px 12px;
+}
+
+/* Preview disclaimer banner */
+.preview-banner {
+	background-color: #fff3cd;
+	color: #856404;
+	padding: 0.75rem;
+	text-align: center;
+	font-weight: 600;
+	font-size: 0.875rem;
+	border-bottom: 2px solid #ffc107;
+	position: sticky;
+	top: 0;
+	z-index: 10;
+}
+
+/* Scrollable phone content */
+.phone-content {
+	flex: 1;
+	overflow-y: auto;
+	background-color: #f5f5f5;
+	-webkit-overflow-scrolling: touch;
+}
+
+/* Motion preview content (replicates voter view) */
+.motion-preview {
+	padding: 1.5rem 1rem;
+}
+
+.motion-header {
+	margin-bottom: 1.5rem;
+}
+
+.motion-header h2 {
+	margin: 0;
+	color: #2c3e50;
+	font-size: 2rem;
+	word-wrap: break-word;
+}
+
+.motion-description {
+	color: #666;
+	margin-bottom: 1.5rem;
+	padding-bottom: 1.5rem;
+	border-bottom: 1px solid #eee;
+}
+
+.motion-description p {
+	margin: 0;
+	line-height: 1.6;
+	white-space: pre-wrap;
+}
+
+.motion-info {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+	gap: 0.5rem;
+	margin-bottom: 2rem;
+}
+
+.info-item {
+	background: #f8f9fa;
+	padding: 0.75rem;
+	border-radius: 4px;
+}
+
+.info-label {
+	display: block;
+	font-size: 0.7rem;
+	color: #888;
+	text-transform: uppercase;
+	margin-bottom: 0.25rem;
+}
+
+.info-value {
+	display: block;
+	font-size: 0.875rem;
+	color: #2c3e50;
+	font-weight: 500;
+	word-wrap: break-word;
+}
+
+.voting-section {
+	border-top: 1px solid #eee;
+	padding-top: 1.5rem;
+}
+
+.voting-section h3 {
+	margin: 0 0 0.5rem 0;
+	color: #2c3e50;
+	font-size: 1.125rem;
+}
+
+.vote-instructions {
+	color: #666;
+	margin-bottom: 1.5rem;
+	font-size: 0.875rem;
+}
+
+.choices-list {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	margin-bottom: 1rem;
+}
+
+.choice-item {
+	display: flex;
+	align-items: center;
+	padding: 0.875rem;
+	background: #f8f9fa;
+	border: 2px solid #dee2e6;
+	border-radius: 8px;
+	cursor: not-allowed;
+	transition: all 0.2s;
+}
+
+.choice-item.disabled {
+	opacity: 0.8;
+}
+
+.choice-checkbox {
+	width: 22px;
+	height: 22px;
+	border: 2px solid #adb5bd;
+	border-radius: 4px;
+	margin-right: 0.875rem;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: white;
+	flex-shrink: 0;
+}
+
+.choice-name {
+	font-size: 0.9375rem;
+	color: #2c3e50;
+	word-wrap: break-word;
+	flex: 1;
+}
+
+.abstain-section {
+	margin-top: 1rem;
+	padding-top: 1rem;
+	border-top: 1px dashed #dee2e6;
+}
+
+.abstain-item {
+	background: #fff3e0;
+	border-color: #ff9800;
+}
+
+.abstain-note {
+	margin: 0.5rem 0 0 0;
+	font-size: 0.75rem;
+	color: #666;
+	font-style: italic;
+}
+
+.submit-section {
+	margin-top: 1.5rem;
+	text-align: center;
+}
+
+.btn {
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	font-weight: 500;
+}
+
+.btn:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+.btn-primary {
+	background-color: #bdbdbd;
+	color: white;
+}
+
+.btn-large {
+	padding: 0.75rem 2rem;
+	font-size: 1rem;
+	width: 100%;
+}
+
+/* Close button (outside phone frame) */
+.close-button {
+	padding: 0.75rem 2rem;
+	background-color: #2c3e50;
+	color: white;
+	border: none;
+	border-radius: 8px;
+	font-size: 1rem;
+	font-weight: 600;
+	cursor: pointer;
+	align-self: center;
+	transition: background-color 0.2s;
+}
+
+.close-button:hover {
+	background-color: #1a252f;
+}
+
+/* Scrollbar styling for phone content */
+.phone-content::-webkit-scrollbar {
+	width: 6px;
+}
+
+.phone-content::-webkit-scrollbar-track {
+	background: #e0e0e0;
+}
+
+.phone-content::-webkit-scrollbar-thumb {
+	background: #9e9e9e;
+	border-radius: 3px;
+}
+
+/* Responsive adjustments for very small screens */
+@media (max-width: 400px) {
+	.phone-frame {
+		width: 100%;
+		border-radius: 24px;
+		padding: 8px;
+	}
+
+	.device-bezel {
+		height: 24px;
+	}
+
+	.notch {
+		width: 120px;
+		height: 16px;
+	}
+}
+</style>

--- a/packages/client/src/views/admin/MotionCreate.vue
+++ b/packages/client/src/views/admin/MotionCreate.vue
@@ -1,8 +1,14 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { useRouter, onBeforeRouteLeave } from "vue-router";
-import { createChoice, createMotion, getPools } from "../../services/api";
-import type { Pool } from "@mcdc-convention-voting/shared";
+import {
+	createChoice,
+	createMotion,
+	getMeeting,
+	getPools,
+} from "../../services/api";
+import MotionPreviewModal from "../../components/MotionPreviewModal.vue";
+import type { Meeting, Pool } from "@mcdc-convention-voting/shared";
 
 const props = defineProps<{
 	meetingId: string;
@@ -25,6 +31,8 @@ const EMPTY_ARRAY_LENGTH = 0;
 
 const pools = ref<Pool[]>([]);
 const loadingPools = ref(false);
+const meeting = ref<Meeting | null>(null);
+const showPreview = ref(false);
 
 const formData = ref({
 	name: EMPTY_STRING,
@@ -67,6 +75,46 @@ async function loadPools(): Promise<void> {
 		loadingPools.value = false;
 	}
 }
+
+async function loadMeeting(): Promise<void> {
+	try {
+		const meetingIdNum = Number.parseInt(props.meetingId, DECIMAL_RADIX);
+		const response = await getMeeting(meetingIdNum);
+		if (response.data !== undefined) {
+			meeting.value = response.data;
+		}
+	} catch (err) {
+		error.value = err instanceof Error ? err.message : "Failed to load meeting";
+	}
+}
+
+const previewData = computed(() => {
+	const pool = pools.value.find(
+		(p) => p.id === Number.parseInt(formData.value.votingPoolId, DECIMAL_RADIX),
+	);
+
+	// Determine pool name - use selected pool or show placeholder
+	const poolName = pool?.poolName ?? "Quorum Pool";
+
+	return {
+		motionName:
+			formData.value.name.trim() === EMPTY_STRING
+				? "Untitled Motion"
+				: formData.value.name,
+		description:
+			formData.value.description.trim() === EMPTY_STRING
+				? null
+				: formData.value.description,
+		selectionCount: formData.value.selectionCount,
+		meetingName: meeting.value?.name ?? "Unknown Meeting",
+		votingPoolName: poolName,
+		choices: pendingChoices.value.map((choice, index) => ({
+			id: index,
+			name: choice,
+			sortOrder: index,
+		})),
+	};
+});
 
 function addPendingChoice(): void {
 	if (newChoiceName.value.trim() === EMPTY_STRING) {
@@ -185,6 +233,7 @@ onBeforeRouteLeave(() => {
 });
 
 onMounted(() => {
+	void loadMeeting();
 	void loadPools();
 	window.addEventListener("beforeunload", handleBeforeUnload);
 });
@@ -346,11 +395,26 @@ onUnmounted(() => {
 				<button type="submit" class="btn btn-primary" :disabled="saving">
 					{{ saving ? "Creating..." : "Create Motion" }}
 				</button>
+				<button
+					type="button"
+					class="btn btn-secondary"
+					:disabled="pendingChoices.length === 0"
+					@click="showPreview = true"
+				>
+					Preview Motion
+				</button>
 				<button type="button" class="btn btn-secondary" @click="cancel">
 					Cancel
 				</button>
 			</div>
 		</form>
+
+		<!-- Preview Modal -->
+		<MotionPreviewModal
+			v-if="showPreview"
+			v-bind="previewData"
+			@close="showPreview = false"
+		/>
 	</div>
 </template>
 

--- a/packages/client/src/views/admin/MotionDetail.vue
+++ b/packages/client/src/views/admin/MotionDetail.vue
@@ -15,6 +15,7 @@ import {
 	deleteChoice,
 	reorderChoices,
 } from "../../services/api";
+import MotionPreviewModal from "../../components/MotionPreviewModal.vue";
 import type {
 	MotionDetailedResults,
 	MotionVoteStats,
@@ -94,6 +95,7 @@ const saving = ref(false);
 const savingChoice = ref(false);
 const error = ref<string | null>(null);
 const choiceError = ref<string | null>(null);
+const showPreview = ref(false);
 
 const canEdit = computed(() => {
 	if (motion.value === null) {
@@ -114,6 +116,49 @@ const isDirty = computed((): boolean => {
 		formData.value.votingPoolId !== savedFormData.value.votingPoolId
 	);
 });
+
+const previewData = computed(
+	(): {
+		motionName: string;
+		description: string | null;
+		selectionCount: number;
+		meetingName: string;
+		votingPoolName: string;
+		choices: Array<{ id: number; name: string; sortOrder: number }>;
+	} | null => {
+		if (motion.value === null) {
+			return null;
+		}
+
+		const pool = pools.value.find(
+			(p) =>
+				p.id === Number.parseInt(formData.value.votingPoolId, DECIMAL_RADIX),
+		);
+
+		// Determine pool name - use selected pool or current voting pool
+		const poolName =
+			pool?.poolName ?? motion.value.votingPoolName ?? "Quorum Pool";
+
+		return {
+			motionName:
+				formData.value.name.trim() === EMPTY_STRING
+					? "Untitled Motion"
+					: formData.value.name,
+			description:
+				formData.value.description.trim() === EMPTY_STRING
+					? null
+					: formData.value.description,
+			selectionCount: formData.value.selectionCount,
+			meetingName: "Meeting Preview",
+			votingPoolName: poolName,
+			choices: choices.value.map((choice) => ({
+				id: choice.id,
+				name: choice.name,
+				sortOrder: choice.sortOrder,
+			})),
+		};
+	},
+);
 
 // Use countdown timer composable
 const { remainingTimeString, isTimeUrgent, isOvertime } = useCountdownTimer({
@@ -879,6 +924,14 @@ watch(
 						<button type="submit" class="btn btn-primary" :disabled="saving">
 							{{ saving ? "Saving..." : "Save Changes" }}
 						</button>
+						<button
+							type="button"
+							class="btn btn-secondary"
+							:disabled="choices.length === 0"
+							@click="showPreview = true"
+						>
+							Preview Motion
+						</button>
 					</div>
 				</form>
 			</template>
@@ -1114,6 +1167,13 @@ watch(
 				</div>
 			</div>
 		</div>
+
+		<!-- Preview Modal -->
+		<MotionPreviewModal
+			v-if="showPreview && previewData"
+			v-bind="previewData"
+			@close="showPreview = false"
+		/>
 	</div>
 </template>
 


### PR DESCRIPTION
## Summary

Implements a motion preview modal that shows admins what voters will see before saving or starting a motion. This helps catch errors and verify motion configuration before publishing to voters.

**Key Features:**
- 📱 Mobile phone emulation (375px width with device chrome and notch)
- 👀 Non-interactive visual preview (no actual voting possible)
- ⚠️ Clear disclaimer banner indicating preview mode
- 🔄 Works with both unsaved (Create) and saved (Edit) motion data
- 👥 Available to both global admins and meeting admins

## Implementation Details

### Phase 1: Reusable Preview Component
Created `MotionPreviewModal.vue` component that:
- Accepts motion data via props (works with both create and edit flows)
- Displays realistic phone frame (375px, device bezel with notch)
- Shows sticky disclaimer: "Preview Mode - No voting will be recorded"
- Replicates exact voter view layout and styling
- Disables all interactive elements (checkboxes, submit button)
- Emits close event for modal dismissal

### Phase 2: Integration into MotionCreate
Modified `MotionCreate.vue` to:
- Load meeting data for display in preview
- Compute preview data from unsaved form state
- Add "Preview Motion" button (disabled when no choices)
- Show modal with current form data

### Phase 3: Integration into MotionDetail
Modified `MotionDetail.vue` to:
- Compute preview data from saved motion state
- Add "Preview Motion" button in edit mode (disabled when no choices)
- Show modal with current motion data

## Files Changed

- **NEW:** `packages/client/src/components/MotionPreviewModal.vue` (~430 lines)
  - Core preview component with phone frame styling
  
- **MODIFIED:** `packages/client/src/views/admin/MotionCreate.vue`
  - Added preview state, meeting loading, preview button
  
- **MODIFIED:** `packages/client/src/views/admin/MotionDetail.vue`
  - Added preview state, computed preview data, preview button

**Total:** 3 files changed, 546 insertions(+), 2 deletions(-)

## Testing

✅ Manual testing completed successfully:
- Preview button appears in MotionCreate view
- Preview button disabled when no choices added
- Preview shows unsaved form data correctly
- Preview button appears in MotionDetail edit mode
- Preview shows saved motion data correctly
- Phone frame renders with device chrome (bezel and notch)
- Disclaimer banner clearly visible
- All interactive elements properly disabled
- Modal closes on overlay click and close button
- No console errors
- Lint and format checks pass

User feedback: "Testing went very well. Nice Job, good interface."

## Code Quality

- ✅ All lint checks pass (`npm run lint`)
- ✅ All format checks pass (`npm run format`)
- ✅ TypeScript type checking passes
- ✅ Strict boolean expressions used throughout
- ✅ No magic numbers (constants defined)
- ✅ Proper error handling

## Authorization

Works correctly for both:
- Global admins (full system access)
- Meeting admins (access to assigned meetings)

Routes with `requiresAdmin: true` already allow both admin types, so no additional authorization work needed.

## Closes

Resolves #98

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)