### PR TITLE
Replace brittle string matching with structured error codes in voter routes

### DIFF
--- a/packages/server/src/errors/index.ts
+++ b/packages/server/src/errors/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Error classes and utilities
+ */
+export { ServiceError } from "./service-error.js";

--- a/packages/server/src/errors/service-error.ts
+++ b/packages/server/src/errors/service-error.ts
@@ -1,0 +1,24 @@
+/**
+ * Custom error class for service-layer errors.
+ * Carries a structured error code for HTTP status mapping.
+ */
+import type { ServiceErrorCode } from "@mcdc-convention-voting/shared";
+
+/**
+ * ServiceError is thrown by service functions when business logic errors occur.
+ * The error code determines the HTTP status code via ERROR_CODE_TO_HTTP_STATUS mapping.
+ *
+ * Usage:
+ * ```typescript
+ * throw new ServiceError(ServiceErrorCode.MOTION_NOT_FOUND, "Motion not found");
+ * ```
+ */
+export class ServiceError extends Error {
+	public readonly code: ServiceErrorCode;
+
+	constructor(code: ServiceErrorCode, message: string) {
+		super(message);
+		this.name = "ServiceError";
+		this.code = code;
+	}
+}

--- a/packages/server/src/routes/voter.ts
+++ b/packages/server/src/routes/voter.ts
@@ -13,6 +13,7 @@ import {
 import { getOpenMotionsForUser } from "../services/motion-service.js";
 import { getPoolsForUser } from "../services/pool-service.js";
 import { castVote, getMotionForVoting } from "../services/vote-service.js";
+import { sendServiceError } from "../utils/error-handler.js";
 import type { Request, Response } from "express";
 import type {
 	ApiErrorResponse,
@@ -30,59 +31,6 @@ import type {
 
 // Number parsing
 const DECIMAL_RADIX = 10;
-
-// HTTP status code constant
-const HTTP_INTERNAL_SERVER_ERROR = 500;
-
-/**
- * Determine HTTP status code for meeting join errors
- */
-function getMeetingJoinErrorStatus(message: string): number {
-	if (
-		message.includes("not found") ||
-		message.includes("not currently active")
-	) {
-		return HTTP_STATUS.CLIENT_ERROR.NOT_FOUND;
-	}
-
-	if (message.includes("not eligible")) {
-		return HTTP_STATUS.CLIENT_ERROR.FORBIDDEN;
-	}
-
-	return HTTP_INTERNAL_SERVER_ERROR;
-}
-
-/**
- * Determine HTTP status code for vote casting errors
- */
-function getVoteCastErrorStatus(message: string): number {
-	if (
-		message.includes("already voted") ||
-		message.includes("Voting has ended") ||
-		message.includes("not currently open")
-	) {
-		return HTTP_STATUS.CLIENT_ERROR.CONFLICT;
-	}
-
-	if (message.includes("not eligible")) {
-		return HTTP_STATUS.CLIENT_ERROR.FORBIDDEN;
-	}
-
-	if (
-		message.includes("Invalid choice") ||
-		message.includes("Cannot select") ||
-		message.includes("Must select") ||
-		message.includes("only select up to")
-	) {
-		return HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST;
-	}
-
-	if (message.includes("not found")) {
-		return HTTP_STATUS.CLIENT_ERROR.NOT_FOUND;
-	}
-
-	return HTTP_INTERNAL_SERVER_ERROR;
-}
 
 export const voterRouter = Router();
 
@@ -288,18 +236,8 @@ voterRouter.post(
 				success: true,
 				data: { vote },
 			});
-		} catch (err) {
-			const message = err instanceof Error ? err.message : "Unknown error";
-			const statusCode = getVoteCastErrorStatus(message);
-			const errorMessage =
-				statusCode === HTTP_INTERNAL_SERVER_ERROR
-					? `Failed to cast vote: ${message}`
-					: message;
-
-			res.status(statusCode).json({
-				success: false,
-				error: errorMessage,
-			});
+		} catch (error) {
+			sendServiceError(res, error, "Failed to cast vote");
 		}
 	},
 );
@@ -415,13 +353,7 @@ voterRouter.post(
 				data: result,
 			});
 		} catch (error) {
-			const message = error instanceof Error ? error.message : "Unknown error";
-			const statusCode = getMeetingJoinErrorStatus(message);
-
-			res.status(statusCode).json({
-				success: false,
-				error: message,
-			});
+			sendServiceError(res, error, "Failed to join meeting");
 		}
 	},
 );

--- a/packages/server/src/services/meeting-participant-service.ts
+++ b/packages/server/src/services/meeting-participant-service.ts
@@ -4,12 +4,14 @@
  */
 import {
 	ParticipantRole,
+	ServiceErrorCode,
 	type CurrentMeetingInfo,
 	type JoinableMeeting,
 	type MeetingParticipant,
 	type MeetingWithPool,
 } from "@mcdc-convention-voting/shared";
 import { db, withTransaction } from "../database/db.js";
+import { ServiceError } from "../errors/service-error.js";
 
 // Array index constants
 const FIRST_ROW = 0;
@@ -231,7 +233,10 @@ export async function joinMeetingAsVoter(
 	);
 
 	if (meetingResult.rows.length === EMPTY_ARRAY_LENGTH) {
-		throw new Error("Meeting not found or not currently active");
+		throw new ServiceError(
+			ServiceErrorCode.MEETING_NOT_ACTIVE,
+			"Meeting not found or not currently active",
+		);
 	}
 
 	// Verify user is in the quorum pool
@@ -243,7 +248,10 @@ export async function joinMeetingAsVoter(
 	);
 
 	if (poolCheck.rows.length === EMPTY_ARRAY_LENGTH) {
-		throw new Error("User is not eligible to join this meeting as a voter");
+		throw new ServiceError(
+			ServiceErrorCode.NOT_ELIGIBLE_FOR_MEETING,
+			"User is not eligible to join this meeting as a voter",
+		);
 	}
 
 	const insertedRow = await withTransaction(async (tx) => {
@@ -482,7 +490,8 @@ export async function joinMeetingAsWatcher(
 	);
 
 	if (meetingResult.rows.length === EMPTY_ARRAY_LENGTH) {
-		throw new Error(
+		throw new ServiceError(
+			ServiceErrorCode.MEETING_NOT_ACTIVE,
 			"Meeting not found, not currently active, or does not allow watchers",
 		);
 	}
@@ -496,7 +505,10 @@ export async function joinMeetingAsWatcher(
 	);
 
 	if (poolCheck.rows.length === EMPTY_ARRAY_LENGTH) {
-		throw new Error("User is not eligible to join this meeting as a watcher");
+		throw new ServiceError(
+			ServiceErrorCode.NOT_ELIGIBLE_FOR_MEETING,
+			"User is not eligible to join this meeting as a watcher",
+		);
 	}
 
 	// Leave any current meeting and insert the new watcher participation in a
@@ -670,7 +682,10 @@ export async function joinMeetingAsAdmin(
 	}>(meetingQuery, { meetingId });
 
 	if (meetingResult.rows.length === EMPTY_ARRAY_LENGTH) {
-		throw new Error(
+		throw new ServiceError(
+			isGlobalAdmin
+				? ServiceErrorCode.MEETING_NOT_FOUND
+				: ServiceErrorCode.MEETING_NOT_ACTIVE,
 			isGlobalAdmin
 				? "Meeting not found"
 				: "Meeting not found or does not have a meeting admin pool",
@@ -687,7 +702,8 @@ export async function joinMeetingAsAdmin(
 		);
 
 		if (poolCheck.rows.length === EMPTY_ARRAY_LENGTH) {
-			throw new Error(
+			throw new ServiceError(
+				ServiceErrorCode.NOT_ELIGIBLE_FOR_MEETING,
 				"User is not eligible to join this meeting as a meeting admin",
 			);
 		}

--- a/packages/server/src/services/vote-service.ts
+++ b/packages/server/src/services/vote-service.ts
@@ -1,14 +1,16 @@
 /**
  * Vote service for voter-facing voting operations
  */
-import { db } from "../database/db.js";
-import type {
-	CastVoteRequest,
-	Choice,
-	MotionForVoting,
-	Vote,
-	VotingEndedReason,
+import {
+	ServiceErrorCode,
+	type CastVoteRequest,
+	type Choice,
+	type MotionForVoting,
+	type Vote,
+	type VotingEndedReason,
 } from "@mcdc-convention-voting/shared";
+import { db } from "../database/db.js";
+import { ServiceError } from "../errors/service-error.js";
 
 // Time conversion constants
 const MILLISECONDS_PER_MINUTE = 60000;
@@ -209,20 +211,38 @@ export async function getMotionForVoting(
 }
 
 /**
- * Get error message for why user cannot vote
+ * Get error code and message for why user cannot vote
  */
-function getVotingDeniedError(reason: VotingEndedReason | undefined): string {
+function getVotingDeniedError(reason: VotingEndedReason | undefined): {
+	code: ServiceErrorCode;
+	message: string;
+} {
 	switch (reason) {
 		case "already_voted":
-			return "You have already voted on this motion";
+			return {
+				code: ServiceErrorCode.ALREADY_VOTED,
+				message: "You have already voted on this motion",
+			};
 		case "not_in_pool":
-			return "You are not eligible to vote on this motion";
+			return {
+				code: ServiceErrorCode.NOT_ELIGIBLE_FOR_MOTION,
+				message: "You are not eligible to vote on this motion",
+			};
 		case "voting_ended":
-			return "Voting has ended for this motion";
+			return {
+				code: ServiceErrorCode.VOTING_CLOSED,
+				message: "Voting has ended for this motion",
+			};
 		case "not_active":
-			return "This motion is not currently open for voting";
+			return {
+				code: ServiceErrorCode.VOTING_CLOSED,
+				message: "This motion is not currently open for voting",
+			};
 		default:
-			return "You cannot vote on this motion";
+			return {
+				code: ServiceErrorCode.FORBIDDEN,
+				message: "You cannot vote on this motion",
+			};
 	}
 }
 
@@ -236,16 +256,23 @@ function validateVoteChoices(
 ): void {
 	// Validate abstain/choice combination
 	if (abstain && choiceIds.length > EMPTY_ARRAY_LENGTH) {
-		throw new Error("Cannot select choices when abstaining");
+		throw new ServiceError(
+			ServiceErrorCode.INVALID_SELECTION_COUNT,
+			"Cannot select choices when abstaining",
+		);
 	}
 
 	if (!abstain && choiceIds.length === EMPTY_ARRAY_LENGTH) {
-		throw new Error("Must select at least one choice or abstain");
+		throw new ServiceError(
+			ServiceErrorCode.INVALID_SELECTION_COUNT,
+			"Must select at least one choice or abstain",
+		);
 	}
 
 	// Validate choice count against seat count
 	if (!abstain && choiceIds.length > motion.selectionCount) {
-		throw new Error(
+		throw new ServiceError(
+			ServiceErrorCode.INVALID_SELECTION_COUNT,
 			`You can only select up to ${String(motion.selectionCount)} choice(s)`,
 		);
 	}
@@ -255,7 +282,10 @@ function validateVoteChoices(
 		const validChoiceIds = new Set(motion.choices.map((c) => c.id));
 		for (const choiceId of choiceIds) {
 			if (!validChoiceIds.has(choiceId)) {
-				throw new Error("Invalid choice selection");
+				throw new ServiceError(
+					ServiceErrorCode.INVALID_CHOICE,
+					"Invalid choice selection",
+				);
 			}
 		}
 	}
@@ -282,12 +312,16 @@ export async function castVote(
 	const motion = await getMotionForVoting(motionId, userId);
 
 	if (motion === null) {
-		throw new Error("Motion not found");
+		throw new ServiceError(
+			ServiceErrorCode.MOTION_NOT_FOUND,
+			"Motion not found",
+		);
 	}
 
 	// Check if user can vote
 	if (!motion.canVote) {
-		throw new Error(getVotingDeniedError(motion.votingEndedReason));
+		const { code, message } = getVotingDeniedError(motion.votingEndedReason);
+		throw new ServiceError(code, message);
 	}
 
 	// Validate choices

--- a/packages/server/src/utils/error-handler.ts
+++ b/packages/server/src/utils/error-handler.ts
@@ -1,0 +1,100 @@
+/**
+ * Error Handler Utilities
+ *
+ * Provides structured error handling with HTTP status code mapping.
+ * This is the single source of truth for error code to status code mapping.
+ */
+import { HTTP_STATUS } from "@pdc/http-status-codes";
+import { ServiceErrorCode } from "@mcdc-convention-voting/shared";
+import { ServiceError } from "../errors/service-error.js";
+import type { Response } from "express";
+
+/** HTTP 500 status code constant */
+const HTTP_INTERNAL_SERVER_ERROR = 500;
+
+/**
+ * Maps ServiceErrorCode to HTTP status codes.
+ * This is the single source of truth for error-to-status mapping.
+ *
+ * Mapping logic:
+ * - Authentication/Authorization → 401/403
+ * - Not found errors → 404
+ * - Conflict/state errors → 409
+ * - Validation errors → 400
+ * - Internal errors → 500
+ */
+const ERROR_CODE_TO_HTTP_STATUS: Record<ServiceErrorCode, number> = {
+	// Authentication & Authorization
+	[ServiceErrorCode.UNAUTHORIZED]: HTTP_STATUS.CLIENT_ERROR.UNAUTHORIZED,
+	[ServiceErrorCode.FORBIDDEN]: HTTP_STATUS.CLIENT_ERROR.FORBIDDEN,
+
+	// Resource not found
+	[ServiceErrorCode.NOT_FOUND]: HTTP_STATUS.CLIENT_ERROR.NOT_FOUND,
+	[ServiceErrorCode.MOTION_NOT_FOUND]: HTTP_STATUS.CLIENT_ERROR.NOT_FOUND,
+	[ServiceErrorCode.MEETING_NOT_FOUND]: HTTP_STATUS.CLIENT_ERROR.NOT_FOUND,
+	[ServiceErrorCode.USER_NOT_FOUND]: HTTP_STATUS.CLIENT_ERROR.NOT_FOUND,
+	[ServiceErrorCode.POOL_NOT_FOUND]: HTTP_STATUS.CLIENT_ERROR.NOT_FOUND,
+	[ServiceErrorCode.CHOICE_NOT_FOUND]: HTTP_STATUS.CLIENT_ERROR.NOT_FOUND,
+
+	// Conflict/state errors
+	[ServiceErrorCode.ALREADY_VOTED]: HTTP_STATUS.CLIENT_ERROR.CONFLICT,
+	[ServiceErrorCode.VOTING_CLOSED]: HTTP_STATUS.CLIENT_ERROR.CONFLICT,
+	[ServiceErrorCode.MEETING_NOT_ACTIVE]: HTTP_STATUS.CLIENT_ERROR.NOT_FOUND,
+	[ServiceErrorCode.ALREADY_IN_MEETING]: HTTP_STATUS.CLIENT_ERROR.CONFLICT,
+	[ServiceErrorCode.NOT_IN_MEETING]: HTTP_STATUS.CLIENT_ERROR.CONFLICT,
+
+	// Eligibility (treated as forbidden)
+	[ServiceErrorCode.NOT_ELIGIBLE_FOR_MOTION]:
+		HTTP_STATUS.CLIENT_ERROR.FORBIDDEN,
+	[ServiceErrorCode.NOT_ELIGIBLE_FOR_MEETING]:
+		HTTP_STATUS.CLIENT_ERROR.FORBIDDEN,
+
+	// Validation errors
+	[ServiceErrorCode.INVALID_CHOICE]: HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST,
+	[ServiceErrorCode.INVALID_SELECTION_COUNT]:
+		HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST,
+	[ServiceErrorCode.INVALID_INPUT]: HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST,
+
+	// Generic
+	[ServiceErrorCode.INTERNAL_ERROR]: HTTP_INTERNAL_SERVER_ERROR,
+};
+
+/**
+ * Get HTTP status code for a ServiceErrorCode.
+ *
+ * @param code - The service error code
+ * @returns The corresponding HTTP status code
+ */
+export function getHttpStatusForErrorCode(code: ServiceErrorCode): number {
+	return ERROR_CODE_TO_HTTP_STATUS[code];
+}
+
+/**
+ * Send an error response, using ServiceError code if available.
+ * Falls back to 500 Internal Server Error for non-ServiceError errors.
+ *
+ * @param res - Express response object
+ * @param error - The error to handle (ServiceError or any Error)
+ * @param fallbackMessage - Message to use if error is not an Error instance
+ */
+export function sendServiceError(
+	res: Response,
+	error: unknown,
+	fallbackMessage = "An error occurred",
+): void {
+	if (error instanceof ServiceError) {
+		const status = getHttpStatusForErrorCode(error.code);
+		res.status(status).json({
+			success: false,
+			error: error.message,
+		});
+		return;
+	}
+
+	// For non-ServiceError errors, use 500 status and error message
+	const message = error instanceof Error ? error.message : fallbackMessage;
+	res.status(HTTP_INTERNAL_SERVER_ERROR).json({
+		success: false,
+		error: message,
+	});
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1190,3 +1190,53 @@ export interface WatcherMotionDetail {
 	// Results (only for completed motions)
 	result: WatcherMotionResult | null;
 }
+
+/**
+ * Service Error Types
+ * Used for structured error handling with proper HTTP status code mapping
+ */
+
+/**
+ * Structured error codes for service-layer errors.
+ * Used to determine HTTP status codes without brittle string matching.
+ *
+ * HTTP Status Code Mapping:
+ * - UNAUTHORIZED → 401
+ * - FORBIDDEN, NOT_ELIGIBLE_* → 403
+ * - NOT_FOUND, *_NOT_FOUND, MEETING_NOT_ACTIVE → 404
+ * - ALREADY_VOTED, VOTING_CLOSED, ALREADY_IN_MEETING, NOT_IN_MEETING → 409
+ * - INVALID_* → 400
+ * - INTERNAL_ERROR → 500
+ */
+export enum ServiceErrorCode {
+	// Authentication & Authorization
+	UNAUTHORIZED = "UNAUTHORIZED",
+	FORBIDDEN = "FORBIDDEN",
+
+	// Resource not found
+	NOT_FOUND = "NOT_FOUND",
+	MOTION_NOT_FOUND = "MOTION_NOT_FOUND",
+	MEETING_NOT_FOUND = "MEETING_NOT_FOUND",
+	USER_NOT_FOUND = "USER_NOT_FOUND",
+	POOL_NOT_FOUND = "POOL_NOT_FOUND",
+	CHOICE_NOT_FOUND = "CHOICE_NOT_FOUND",
+
+	// Conflict/state errors
+	ALREADY_VOTED = "ALREADY_VOTED",
+	VOTING_CLOSED = "VOTING_CLOSED",
+	MEETING_NOT_ACTIVE = "MEETING_NOT_ACTIVE",
+	ALREADY_IN_MEETING = "ALREADY_IN_MEETING",
+	NOT_IN_MEETING = "NOT_IN_MEETING",
+
+	// Eligibility
+	NOT_ELIGIBLE_FOR_MOTION = "NOT_ELIGIBLE_FOR_MOTION",
+	NOT_ELIGIBLE_FOR_MEETING = "NOT_ELIGIBLE_FOR_MEETING",
+
+	// Validation errors
+	INVALID_CHOICE = "INVALID_CHOICE",
+	INVALID_SELECTION_COUNT = "INVALID_SELECTION_COUNT",
+	INVALID_INPUT = "INVALID_INPUT",
+
+	// Generic
+	INTERNAL_ERROR = "INTERNAL_ERROR",
+}


### PR DESCRIPTION
## Summary
- Adds `ServiceErrorCode` enum to shared types for semantic error identification
- Creates `ServiceError` class that carries structured error codes
- Adds `error-handler.ts` with `ERROR_CODE_TO_HTTP_STATUS` mapping as single source of truth
- Updates `vote-service.ts` and `meeting-participant-service.ts` to throw `ServiceError`
- Removes ~50 lines of brittle string matching functions from `voter.ts`

## Test plan
- [ ] Run existing voter route tests (`npm run test`)
- [ ] Verify error responses still return correct HTTP status codes:
  - Vote on non-existent motion → 404
  - Duplicate vote → 409
  - Vote when not eligible → 403
  - Invalid choice IDs → 400
  - Join non-existent meeting → 404
  - Join inactive meeting → 404

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)