### PR TITLE
Replace brittle string matching with structured error codes (#30)

### DIFF
--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -409,7 +409,7 @@ adminRouter.get(
 adminRouter.post(
 	"/users",
 	requireAdminOrMeetingAdmin,
-	 
+
 	async (req: Request, res: Response) => {
 		try {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -409,7 +409,7 @@ adminRouter.get(
 adminRouter.post(
 	"/users",
 	requireAdminOrMeetingAdmin,
-	// eslint-disable-next-line complexity -- additional validation for meeting admins
+	 
 	async (req: Request, res: Response) => {
 		try {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Express req.body is any
@@ -453,10 +453,7 @@ adminRouter.post(
 				.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 				.json({ success: true, data: user });
 		} catch (error) {
-			const message = error instanceof Error ? error.message : "Unknown error";
-			res
-				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-				.json({ error: `Failed to create user: ${message}` });
+			sendServiceError(res, error, "Failed to create user");
 		}
 	},
 );
@@ -649,10 +646,7 @@ adminRouter.put(
 			const user = await updateUser(req.params.id, updates);
 			res.json({ success: true, data: user });
 		} catch (error) {
-			const message = error instanceof Error ? error.message : "Unknown error";
-			res
-				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-				.json({ error: `Failed to update user: ${message}` });
+			sendServiceError(res, error, "Failed to update user");
 		}
 	},
 );
@@ -678,10 +672,7 @@ adminRouter.post(
 			const user = await disableUser(req.params.id);
 			res.json({ success: true, data: user });
 		} catch (error) {
-			const message = error instanceof Error ? error.message : "Unknown error";
-			res
-				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-				.json({ error: `Failed to disable user: ${message}` });
+			sendServiceError(res, error, "Failed to disable user");
 		}
 	},
 );
@@ -698,10 +689,7 @@ adminRouter.post(
 			const user = await enableUser(req.params.id);
 			res.json({ success: true, data: user });
 		} catch (error) {
-			const message = error instanceof Error ? error.message : "Unknown error";
-			res
-				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-				.json({ error: `Failed to enable user: ${message}` });
+			sendServiceError(res, error, "Failed to enable user");
 		}
 	},
 );
@@ -718,11 +706,7 @@ adminRouter.delete(
 			await deleteUser(req.params.id);
 			res.json({ success: true });
 		} catch (error) {
-			const message = error instanceof Error ? error.message : "Unknown error";
-			const status = message.includes("not found")
-				? HTTP_STATUS.CLIENT_ERROR.NOT_FOUND
-				: HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST;
-			res.status(status).json({ error: `Failed to delete user: ${message}` });
+			sendServiceError(res, error, "Failed to delete user");
 		}
 	},
 );
@@ -1040,10 +1024,7 @@ adminRouter.post(
 				.status(HTTP_STATUS.SUCCESSFUL.CREATED)
 				.json({ success: true, data: pool });
 		} catch (error) {
-			const message = error instanceof Error ? error.message : "Unknown error";
-			res
-				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-				.json({ error: `Failed to create pool: ${message}` });
+			sendServiceError(res, error, "Failed to create pool");
 		}
 	},
 );
@@ -1283,10 +1264,7 @@ adminRouter.put(
 			const { pool, resolvedUsers } = await updatePool(poolId, updates);
 			res.json({ success: true, data: pool, resolvedUsers });
 		} catch (error) {
-			const message = error instanceof Error ? error.message : "Unknown error";
-			res
-				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-				.json({ error: `Failed to update pool: ${message}` });
+			sendServiceError(res, error, "Failed to update pool");
 		}
 	},
 );
@@ -1304,10 +1282,7 @@ adminRouter.post(
 			const pool = await disablePool(poolId);
 			res.json({ success: true, data: pool });
 		} catch (error) {
-			const message = error instanceof Error ? error.message : "Unknown error";
-			res
-				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-				.json({ error: `Failed to disable pool: ${message}` });
+			sendServiceError(res, error, "Failed to disable pool");
 		}
 	},
 );
@@ -1325,10 +1300,7 @@ adminRouter.post(
 			const pool = await enablePool(poolId);
 			res.json({ success: true, data: pool });
 		} catch (error) {
-			const message = error instanceof Error ? error.message : "Unknown error";
-			res
-				.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
-				.json({ error: `Failed to enable pool: ${message}` });
+			sendServiceError(res, error, "Failed to enable pool");
 		}
 	},
 );

--- a/packages/server/src/services/pool-service.ts
+++ b/packages/server/src/services/pool-service.ts
@@ -3,12 +3,14 @@
  */
 import {
 	PoolType,
-	type Pool,
+	ServiceErrorCode,
 	type CreatePoolRequest,
+	type Pool,
 	type UpdatePoolRequest,
 	type User,
 } from "@mcdc-convention-voting/shared";
 import { db, withTransaction } from "../database/db.js";
+import { ServiceError } from "../errors/service-error.js";
 import { recordPendingPoolKeys } from "./pending-pool-service.js";
 import type { TinyPg } from "tinypg";
 
@@ -306,7 +308,10 @@ export async function createPool(request: CreatePoolRequest): Promise<Pool> {
 
 	// Check if pool key already exists
 	if (await poolKeyExists(poolKey)) {
-		throw new Error(`Pool with key ${poolKey} already exists`);
+		throw new ServiceError(
+			ServiceErrorCode.INVALID_INPUT,
+			`Pool with key ${poolKey} already exists`,
+		);
 	}
 
 	const result = await db.query<PoolDbRow>(
@@ -425,7 +430,10 @@ export async function updatePool(
 
 		const { rows: poolRows } = currentPoolResult;
 		if (poolRows.length === EMPTY_ARRAY_LENGTH) {
-			throw new Error(`Pool with ID ${poolId} not found`);
+			throw new ServiceError(
+				ServiceErrorCode.POOL_NOT_FOUND,
+				`Pool with ID ${poolId} not found`,
+			);
 		}
 
 		const [{ pool_key: oldPoolKey }] = poolRows;
@@ -443,12 +451,18 @@ export async function updatePool(
 				{ newPoolKey, poolId },
 			);
 			if (existingPool.rows.length > EMPTY_ARRAY_LENGTH) {
-				throw new Error(`Pool key ${newPoolKey} already exists`);
+				throw new ServiceError(
+					ServiceErrorCode.INVALID_INPUT,
+					`Pool key ${newPoolKey} already exists`,
+				);
 			}
 		}
 
 		if (setClauses.length === EMPTY_ARRAY_LENGTH) {
-			throw new Error("No fields to update");
+			throw new ServiceError(
+				ServiceErrorCode.INVALID_INPUT,
+				"No fields to update",
+			);
 		}
 
 		setClauses.push("updated_at = NOW()");
@@ -490,7 +504,10 @@ export async function disablePool(poolId: number): Promise<Pool> {
 	);
 
 	if (result.rows.length === EMPTY_ARRAY_LENGTH) {
-		throw new Error(`Pool with ID ${poolId} not found`);
+		throw new ServiceError(
+			ServiceErrorCode.POOL_NOT_FOUND,
+			`Pool with ID ${poolId} not found`,
+		);
 	}
 
 	return mapRowToPool(result.rows[FIRST_ROW]);
@@ -509,7 +526,10 @@ export async function enablePool(poolId: number): Promise<Pool> {
 	);
 
 	if (result.rows.length === EMPTY_ARRAY_LENGTH) {
-		throw new Error(`Pool with ID ${poolId} not found`);
+		throw new ServiceError(
+			ServiceErrorCode.POOL_NOT_FOUND,
+			`Pool with ID ${poolId} not found`,
+		);
 	}
 
 	return mapRowToPool(result.rows[FIRST_ROW]);

--- a/packages/server/src/services/user-service.ts
+++ b/packages/server/src/services/user-service.ts
@@ -1,19 +1,21 @@
 /**
  * User management service
  */
+import {
+	ServiceErrorCode,
+	type CreateUserRequest,
+	type GeneratePasswordsRequest,
+	type PasswordGenerationProgress,
+	type PasswordGenerationResult,
+	type SystemSettings,
+	type UpdateUserRequest,
+	type User,
+} from "@mcdc-convention-voting/shared";
 import { db, withTransaction } from "../database/db.js";
+import { ServiceError } from "../errors/service-error.js";
 import { generatePassword, hashPassword } from "../utils/password-generator.js";
 import { generateUniqueUsername } from "../utils/username-generator.js";
 import { setUserPools } from "./pool-service.js";
-import type {
-	User,
-	CreateUserRequest,
-	UpdateUserRequest,
-	PasswordGenerationResult,
-	PasswordGenerationProgress,
-	SystemSettings,
-	GeneratePasswordsRequest,
-} from "@mcdc-convention-voting/shared";
 
 // Array index constants
 const FIRST_ROW = 0;
@@ -82,14 +84,18 @@ async function validateAndPrepareUserCreation(
 		finalIsMeetingAdmin,
 	].filter(Boolean);
 	if (roleCount > MAX_ALLOWED_SPECIAL_ROLES) {
-		throw new Error(
+		throw new ServiceError(
+			ServiceErrorCode.INVALID_INPUT,
 			"User can only have one role: admin, watcher, or meeting_admin",
 		);
 	}
 
 	// Check if voter ID already exists
 	if (await voterIdExists(voterId)) {
-		throw new Error(`User with voter ID ${voterId} already exists`);
+		throw new ServiceError(
+			ServiceErrorCode.INVALID_INPUT,
+			`User with voter ID ${voterId} already exists`,
+		);
 	}
 
 	// Generate username if not provided
@@ -100,7 +106,10 @@ async function validateAndPrepareUserCreation(
 
 	// Check if username already exists (in case one was provided)
 	if (await usernameExists(finalUsername)) {
-		throw new Error(`Username ${finalUsername} already exists`);
+		throw new ServiceError(
+			ServiceErrorCode.INVALID_INPUT,
+			`Username ${finalUsername} already exists`,
+		);
 	}
 
 	return { finalUsername, finalIsAdmin, finalIsWatcher, finalIsMeetingAdmin };
@@ -198,7 +207,10 @@ export async function upsertUser(request: CreateUserRequest): Promise<User> {
 
 	// Validate role exclusivity
 	if (finalIsAdmin && finalIsWatcher) {
-		throw new Error("User cannot be both admin and watcher");
+		throw new ServiceError(
+			ServiceErrorCode.INVALID_INPUT,
+			"User cannot be both admin and watcher",
+		);
 	}
 
 	// Generate username for potential insert (will be ignored if user exists)
@@ -737,7 +749,10 @@ export async function updateUser(
 			);
 			// Only throw error if it's a different user
 			if (existingUser.rows[FIRST_ROW].id !== userId) {
-				throw new Error(`Voter ID ${voterId} already exists`);
+				throw new ServiceError(
+					ServiceErrorCode.INVALID_INPUT,
+					`Voter ID ${voterId} already exists`,
+				);
 			}
 		}
 		setClauses.push(`voter_id = :voterId`);
@@ -763,7 +778,10 @@ export async function updateUser(
 			);
 			// Only throw error if it's a different user
 			if (existingUser.rows[FIRST_ROW].id !== userId) {
-				throw new Error(`Username ${username} already exists`);
+				throw new ServiceError(
+					ServiceErrorCode.INVALID_INPUT,
+					`Username ${username} already exists`,
+				);
 			}
 		}
 		setClauses.push(`username = :username`);
@@ -778,7 +796,10 @@ export async function updateUser(
 	}
 
 	if (setClauses.length === EMPTY_ARRAY_LENGTH && poolKeys === undefined) {
-		throw new Error("No fields to update");
+		throw new ServiceError(
+			ServiceErrorCode.INVALID_INPUT,
+			"No fields to update",
+		);
 	}
 
 	// Update user fields if there are any changes
@@ -809,7 +830,10 @@ export async function updateUser(
 		);
 
 		if (result.rows.length === EMPTY_ARRAY_LENGTH) {
-			throw new Error(`User with ID ${userId} not found`);
+			throw new ServiceError(
+				ServiceErrorCode.USER_NOT_FOUND,
+				`User with ID ${userId} not found`,
+			);
 		}
 
 		const {
@@ -832,7 +856,10 @@ export async function updateUser(
 		// No user fields to update, just fetch the user
 		const existingUser = await getUserById(userId);
 		if (existingUser === null) {
-			throw new Error(`User with ID ${userId} not found`);
+			throw new ServiceError(
+				ServiceErrorCode.USER_NOT_FOUND,
+				`User with ID ${userId} not found`,
+			);
 		}
 		user = existingUser;
 	}
@@ -870,7 +897,10 @@ export async function disableUser(userId: string): Promise<User> {
 	);
 
 	if (result.rows.length === EMPTY_ARRAY_LENGTH) {
-		throw new Error(`User with ID ${userId} not found`);
+		throw new ServiceError(
+			ServiceErrorCode.USER_NOT_FOUND,
+			`User with ID ${userId} not found`,
+		);
 	}
 
 	const {
@@ -916,7 +946,10 @@ export async function enableUser(userId: string): Promise<User> {
 	);
 
 	if (result.rows.length === EMPTY_ARRAY_LENGTH) {
-		throw new Error(`User with ID ${userId} not found`);
+		throw new ServiceError(
+			ServiceErrorCode.USER_NOT_FOUND,
+			`User with ID ${userId} not found`,
+		);
 	}
 
 	const {
@@ -1231,7 +1264,10 @@ export async function resetUserPassword(userId: string): Promise<string> {
 	);
 
 	if (result.rows.length === EMPTY_ARRAY_LENGTH) {
-		throw new Error(`User with ID ${userId} not found`);
+		throw new ServiceError(
+			ServiceErrorCode.USER_NOT_FOUND,
+			`User with ID ${userId} not found`,
+		);
 	}
 
 	return password;
@@ -1448,11 +1484,17 @@ export async function deleteUser(userId: string): Promise<void> {
 	);
 
 	if (userCheck.rows.length === EMPTY_ARRAY_LENGTH) {
-		throw new Error(`User with ID ${userId} not found`);
+		throw new ServiceError(
+			ServiceErrorCode.USER_NOT_FOUND,
+			`User with ID ${userId} not found`,
+		);
 	}
 
 	if (userCheck.rows[FIRST_ROW].is_admin) {
-		throw new Error("Cannot delete admin users");
+		throw new ServiceError(
+			ServiceErrorCode.FORBIDDEN,
+			"Cannot delete admin users",
+		);
 	}
 
 	// Delete user_pools associations first


### PR DESCRIPTION
## Summary

This PR refactors the error handling system to replace brittle string matching with structured error codes, addressing Issue #30.

### Problem
The previous implementation used string matching to determine HTTP status codes:
```typescript
// Before - fragile!
if (message.includes("already voted") || message.includes("Voting has ended")) {
    return HTTP_STATUS.CLIENT_ERROR.CONFLICT;
}
```

This approach was:
- **Brittle**: Minor wording changes broke status code mapping
- **Unmaintainable**: Adding new error types required updating multiple files
- **Error-prone**: Typos in error messages led to wrong status codes

### Solution
Implemented a three-phase refactoring:

**Phase 1: Infrastructure + Voter Routes** (30c089f)
- Added `ServiceErrorCode` enum in shared package
- Created `ServiceError` class in server
- Added `sendServiceError()` helper with `ERROR_CODE_TO_HTTP_STATUS` mapping
- Updated vote-service.ts and meeting-participant-service.ts
- Simplified voter.ts routes

**Phase 2: Meeting/Motion/Choice Routes** (263b07e)
- Updated meeting-service.ts with ServiceError
- Updated admin.ts meeting, motion, and choice routes

**Phase 3: User/Pool Routes** (a0f6bd8)
- Updated user-service.ts with ServiceError
- Updated pool-service.ts with ServiceError
- Updated admin.ts user and pool routes
- Reviewed csv-service.ts and auth-service.ts (no changes needed)

### HTTP Status Mapping

| ServiceErrorCode | HTTP Status |
|------------------|-------------|
| `UNAUTHORIZED` | 401 |
| `FORBIDDEN` | 403 |
| `*_NOT_FOUND` | 404 |
| `ALREADY_VOTED`, `VOTING_CLOSED` | 409 |
| `NOT_ELIGIBLE_*` | 403 |
| `INVALID_*` | 400 |
| `INTERNAL_ERROR` | 500 |

## Test plan

- [x] API tests verify correct HTTP status codes:
  - USER_NOT_FOUND → 404 ✓
  - POOL_NOT_FOUND → 404 ✓
  - MEETING_NOT_FOUND → 404 ✓
  - INVALID_INPUT (multiple roles) → 400 ✓
  - INVALID_INPUT (duplicate pool key) → 400 ✓
  - INVALID_INPUT (duplicate voter ID) → 400 ✓
- [x] UI testing verified error handling through the interface
- [x] Lint and typecheck pass
- [x] Error messages remain unchanged (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)