### PR TITLE
Optimize vote-service for stress test performance

### DIFF
--- a/packages/client/src/services/api.ts
+++ b/packages/client/src/services/api.ts
@@ -497,7 +497,7 @@ export async function generatePasswordsWithProgress(
 
 				// Progress update
 				if (onProgress !== undefined) {
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- Progress data matches PasswordGenerationProgress interface
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- SSE progress data validated by server, matches PasswordGenerationProgress
 					onProgress(data);
 				}
 			} catch (error) {

--- a/packages/server/src/services/vote-service.test.ts
+++ b/packages/server/src/services/vote-service.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Unit tests for vote-service
+ *
+ * These tests verify the SQL patterns and logic used in vote operations.
+ * The database is mocked to test query structure and result handling.
+ */
+/* eslint-disable @typescript-eslint/no-unsafe-type-assertion -- Test mocks require type assertions */
+/* eslint-disable @typescript-eslint/unbound-method -- db.query mock is safe to use unbound in tests */
+/* eslint-disable import/order -- vi.mock must be called before importing mocked modules */
+/* eslint-disable @typescript-eslint/prefer-destructuring -- Dynamic array access is clearer for mock.calls */
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+
+// Mock the database module before importing vote-service
+vi.mock("../database/db.js", () => ({
+	db: {
+		query: vi.fn(),
+	},
+}));
+
+// Mock the ServiceError import
+vi.mock("../errors/service-error.js", () => ({
+	ServiceError: class ServiceError extends Error {
+		code: string;
+		constructor(code: string, message: string) {
+			super(message);
+			this.code = code;
+		}
+	},
+}));
+
+// Import after mocking
+import { db } from "../database/db.js";
+import { hasUserVoted, isUserInVotingPool, castVote } from "./vote-service.js";
+
+describe("vote-service", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe("hasUserVoted", () => {
+		it("should return true when user has voted (EXISTS returns true)", async () => {
+			const mockQuery = db.query as Mock;
+			mockQuery.mockResolvedValueOnce({
+				rows: [{ exists: true }],
+			});
+
+			const result = await hasUserVoted("user-123", 1);
+
+			expect(result).toBe(true);
+			expect(mockQuery).toHaveBeenCalledTimes(1);
+
+			// Verify the query uses EXISTS pattern
+			const firstCall = mockQuery.mock.calls[0] as [string, unknown];
+			const [query] = firstCall;
+			expect(query).toContain("EXISTS");
+			expect(query).toContain("SELECT 1");
+		});
+
+		it("should return false when user has not voted (EXISTS returns false)", async () => {
+			const mockQuery = db.query as Mock;
+			mockQuery.mockResolvedValueOnce({
+				rows: [{ exists: false }],
+			});
+
+			const result = await hasUserVoted("user-456", 2);
+
+			expect(result).toBe(false);
+			expect(mockQuery).toHaveBeenCalledTimes(1);
+		});
+
+		it("should pass correct parameters to query", async () => {
+			const mockQuery = db.query as Mock;
+			mockQuery.mockResolvedValueOnce({
+				rows: [{ exists: false }],
+			});
+
+			await hasUserVoted("test-user-id", 42);
+
+			const firstCall = mockQuery.mock.calls[0] as [
+				string,
+				{ userId: string; motionId: number },
+			];
+			const [, params] = firstCall;
+			expect(params.userId).toBe("test-user-id");
+			expect(params.motionId).toBe(42);
+		});
+	});
+
+	describe("isUserInVotingPool", () => {
+		it("should return true when user is in voting pool (EXISTS returns true)", async () => {
+			const mockQuery = db.query as Mock;
+			mockQuery.mockResolvedValueOnce({
+				rows: [{ exists: true }],
+			});
+
+			const result = await isUserInVotingPool("user-123", 1);
+
+			expect(result).toBe(true);
+			expect(mockQuery).toHaveBeenCalledTimes(1);
+
+			// Verify the query uses EXISTS pattern
+			const firstCall = mockQuery.mock.calls[0] as [string, unknown];
+			const [query] = firstCall;
+			expect(query).toContain("EXISTS");
+			expect(query).toContain("SELECT 1");
+		});
+
+		it("should return false when user is not in voting pool (EXISTS returns false)", async () => {
+			const mockQuery = db.query as Mock;
+			mockQuery.mockResolvedValueOnce({
+				rows: [{ exists: false }],
+			});
+
+			const result = await isUserInVotingPool("user-456", 2);
+
+			expect(result).toBe(false);
+			expect(mockQuery).toHaveBeenCalledTimes(1);
+		});
+
+		it("should handle COALESCE for motion vs meeting pool", async () => {
+			const mockQuery = db.query as Mock;
+			mockQuery.mockResolvedValueOnce({
+				rows: [{ exists: true }],
+			});
+
+			await isUserInVotingPool("user-123", 1);
+
+			// Verify query uses COALESCE to check motion pool first, then meeting pool
+			const firstCall = mockQuery.mock.calls[0] as [string, unknown];
+			const [query] = firstCall;
+			expect(query).toContain("COALESCE");
+			expect(query).toContain("voting_pool_id");
+			expect(query).toContain("quorum_voting_pool_id");
+		});
+	});
+
+	describe("castVote - batch insert", () => {
+		it("should use batch UNNEST for multiple choice inserts", async () => {
+			const mockQuery = db.query as Mock;
+
+			// Mock getMotionForVoting internal calls
+			// 1. Motion query
+			mockQuery.mockResolvedValueOnce({
+				rows: [
+					{
+						id: 1,
+						name: "Test Motion",
+						description: null,
+						planned_duration: 5,
+						selection_count: 3,
+						status: "voting_active",
+						pool_name: "Test Pool",
+						meeting_id: 1,
+						meeting_name: "Test Meeting",
+						end_override: null,
+						voting_started_at: new Date(),
+					},
+				],
+			});
+
+			// 2. Choices query
+			mockQuery.mockResolvedValueOnce({
+				rows: [
+					{
+						id: 10,
+						motion_id: 1,
+						name: "Choice A",
+						sort_order: 0,
+						created_at: new Date(),
+						updated_at: new Date(),
+					},
+					{
+						id: 11,
+						motion_id: 1,
+						name: "Choice B",
+						sort_order: 1,
+						created_at: new Date(),
+						updated_at: new Date(),
+					},
+					{
+						id: 12,
+						motion_id: 1,
+						name: "Choice C",
+						sort_order: 2,
+						created_at: new Date(),
+						updated_at: new Date(),
+					},
+				],
+			});
+
+			// 3. hasUserVoted (EXISTS)
+			mockQuery.mockResolvedValueOnce({
+				rows: [{ exists: false }],
+			});
+
+			// 4. isUserInVotingPool (EXISTS)
+			mockQuery.mockResolvedValueOnce({
+				rows: [{ exists: true }],
+			});
+
+			// 5. Insert vote
+			mockQuery.mockResolvedValueOnce({
+				rows: [
+					{
+						id: 100,
+						user_id: "user-123",
+						motion_id: 1,
+						is_abstain: false,
+						created_at: new Date(),
+					},
+				],
+			});
+
+			// 6. Batch insert vote_choices (the key test)
+			mockQuery.mockResolvedValueOnce({ rows: [] });
+
+			await castVote("user-123", 1, {
+				choiceIds: [10, 11, 12],
+				abstain: false,
+			});
+
+			// The last query should be the batch insert
+			const { length: callCount } = mockQuery.mock.calls;
+			const lastCall = mockQuery.mock.calls[callCount - 1] as [
+				string,
+				{ voteId: number; choiceIds: number[] },
+			];
+			const [query, params] = lastCall;
+
+			// Verify batch insert uses UNNEST
+			expect(query).toContain("UNNEST");
+			expect(query).toContain("INSERT INTO vote_choices");
+			expect(params.voteId).toBe(100);
+			expect(params.choiceIds).toEqual([10, 11, 12]);
+		});
+
+		it("should not insert vote_choices when abstaining", async () => {
+			const mockQuery = db.query as Mock;
+
+			// Mock getMotionForVoting internal calls
+			mockQuery.mockResolvedValueOnce({
+				rows: [
+					{
+						id: 1,
+						name: "Test Motion",
+						description: null,
+						planned_duration: 5,
+						selection_count: 1,
+						status: "voting_active",
+						pool_name: "Test Pool",
+						meeting_id: 1,
+						meeting_name: "Test Meeting",
+						end_override: null,
+						voting_started_at: new Date(),
+					},
+				],
+			});
+
+			mockQuery.mockResolvedValueOnce({
+				rows: [
+					{
+						id: 10,
+						motion_id: 1,
+						name: "Choice A",
+						sort_order: 0,
+						created_at: new Date(),
+						updated_at: new Date(),
+					},
+				],
+			});
+
+			mockQuery.mockResolvedValueOnce({
+				rows: [{ exists: false }],
+			});
+
+			mockQuery.mockResolvedValueOnce({
+				rows: [{ exists: true }],
+			});
+
+			mockQuery.mockResolvedValueOnce({
+				rows: [
+					{
+						id: 100,
+						user_id: "user-123",
+						motion_id: 1,
+						is_abstain: true,
+						created_at: new Date(),
+					},
+				],
+			});
+
+			await castVote("user-123", 1, {
+				choiceIds: [],
+				abstain: true,
+			});
+
+			// Should have exactly 5 queries (no vote_choices insert)
+			expect(mockQuery).toHaveBeenCalledTimes(5);
+
+			// Verify no UNNEST/vote_choices query was made
+			const allQueries = mockQuery.mock.calls.map(
+				(call) => (call as [string, unknown])[0],
+			);
+			const voteChoicesInserts = allQueries.filter((q) =>
+				q.includes("vote_choices"),
+			);
+			expect(voteChoicesInserts).toHaveLength(0);
+		});
+	});
+});

--- a/packages/server/src/services/vote-service.ts
+++ b/packages/server/src/services/vote-service.ts
@@ -15,12 +15,9 @@ import { ServiceError } from "../errors/service-error.js";
 // Time conversion constants
 const MILLISECONDS_PER_MINUTE = 60000;
 
-// Array length constants
+// Array index constants
 const EMPTY_ARRAY_LENGTH = 0;
 const FIRST_ROW = 0;
-
-// Number parsing
-const DECIMAL_RADIX = 10;
 
 /**
  * Database row type for motion query
@@ -64,40 +61,44 @@ interface VoteRow {
 
 /**
  * Check if user has already voted on a motion
+ * Uses EXISTS for efficient early termination - stops at first match
  */
 export async function hasUserVoted(
 	userId: string,
 	motionId: number,
 ): Promise<boolean> {
-	const result = await db.query<{ count: string }>(
-		`SELECT COUNT(*) as count FROM votes
-		 WHERE user_id = :userId AND motion_id = :motionId`,
+	const result = await db.query<{ exists: boolean }>(
+		`SELECT EXISTS(
+			SELECT 1 FROM votes
+			WHERE user_id = :userId AND motion_id = :motionId
+		) as exists`,
 		{ userId, motionId },
 	);
 
-	const count = parseInt(result.rows[FIRST_ROW].count, DECIMAL_RADIX);
-	return count > EMPTY_ARRAY_LENGTH;
+	return result.rows[FIRST_ROW].exists;
 }
 
 /**
  * Check if user is in the motion's voting pool
  * Uses motion's voting_pool_id, or falls back to meeting's quorum_voting_pool_id
+ * Uses EXISTS for efficient early termination - stops at first match
  */
 export async function isUserInVotingPool(
 	userId: string,
 	motionId: number,
 ): Promise<boolean> {
-	const result = await db.query<{ count: string }>(
-		`SELECT COUNT(*) as count
-		 FROM motions m
-		 INNER JOIN meetings mt ON m.meeting_id = mt.id
-		 INNER JOIN user_pools up ON up.pool_id = COALESCE(m.voting_pool_id, mt.quorum_voting_pool_id)
-		 WHERE m.id = :motionId AND up.user_id = :userId`,
+	const result = await db.query<{ exists: boolean }>(
+		`SELECT EXISTS(
+			SELECT 1
+			FROM motions m
+			INNER JOIN meetings mt ON m.meeting_id = mt.id
+			INNER JOIN user_pools up ON up.pool_id = COALESCE(m.voting_pool_id, mt.quorum_voting_pool_id)
+			WHERE m.id = :motionId AND up.user_id = :userId
+		) as exists`,
 		{ userId, motionId },
 	);
 
-	const count = parseInt(result.rows[FIRST_ROW].count, DECIMAL_RADIX);
-	return count > EMPTY_ARRAY_LENGTH;
+	return result.rows[FIRST_ROW].exists;
 }
 
 /**
@@ -338,16 +339,13 @@ export async function castVote(
 	// eslint-disable-next-line @typescript-eslint/prefer-destructuring -- Array destructuring is appropriate here
 	const [voteRow] = voteResult.rows;
 
-	// Insert vote choices if not abstaining
+	// Insert vote choices if not abstaining - batch insert using UNNEST
 	if (!abstain && choiceIds.length > EMPTY_ARRAY_LENGTH) {
-		for (const choiceId of choiceIds) {
-			// eslint-disable-next-line no-await-in-loop -- Sequential inserts required for vote choices
-			await db.query(
-				`INSERT INTO vote_choices (vote_id, choice_id)
-				 VALUES (:voteId, :choiceId)`,
-				{ voteId: voteRow.id, choiceId },
-			);
-		}
+		await db.query(
+			`INSERT INTO vote_choices (vote_id, choice_id)
+			 SELECT :voteId, UNNEST(:choiceIds::integer[])`,
+			{ voteId: voteRow.id, choiceIds },
+		);
 	}
 
 	return {


### PR DESCRIPTION
## Summary

Addresses remaining performance optimizations from Issue #73 (K6 stress test results):

- **EXISTS pattern**: Changed `hasUserVoted` and `isUserInVotingPool` from `COUNT(*)` to `EXISTS` - stops at first match instead of scanning all rows
- **Batch INSERT**: Changed vote choice inserts from sequential loop (N queries) to single batch INSERT using `UNNEST` (1 query)
- **Unit tests**: Added 8 tests verifying the optimized SQL patterns

## Performance Impact

| Operation | Before | After |
|-----------|--------|-------|
| `hasUserVoted` | COUNT(*) scans all matches | EXISTS stops at first |
| `isUserInVotingPool` | COUNT(*) with JOINs | EXISTS stops at first |
| Vote with 3 choices | 3 INSERT queries | 1 INSERT query |

## Test plan

- [x] All 8 new unit tests pass
- [x] Lint passes with zero warnings
- [x] Typecheck passes
- [ ] Manual testing with actual database (if available)

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)