### PR TITLE
Add per-username login rate limiting (Issue #31)

### DIFF
--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -7,6 +7,12 @@ import { LoginErrorCode } from "@mcdc-convention-voting/shared";
 import { validateLogin, generateToken } from "../services/auth-service.js";
 import { requireAuth } from "../middleware/auth-middleware.js";
 import { leaveCurrentMeeting } from "../services/meeting-participant-service.js";
+import {
+	checkRateLimit,
+	recordFailedLogin,
+	recordSuccessfulLogin,
+	type RateLimitCheckResult,
+} from "../services/login-rate-limiter.js";
 import type { Request, Response } from "express";
 import type {
 	ApiErrorResponse,
@@ -17,6 +23,10 @@ import type {
 } from "@mcdc-convention-voting/shared";
 
 export const authRouter = Router();
+
+// Time conversion constants
+const MILLISECONDS_PER_SECOND = 1000;
+const DEFAULT_RETRY_MS = 0;
 
 /**
  * Get HTTP status code for login error
@@ -29,6 +39,8 @@ function getLoginErrorStatus(errorCode: LoginErrorCode): number {
 		case LoginErrorCode.AccountDisabled:
 		case LoginErrorCode.LoginDisabled:
 			return HTTP_STATUS.CLIENT_ERROR.FORBIDDEN;
+		case LoginErrorCode.RateLimited:
+			return HTTP_STATUS.CLIENT_ERROR.TOO_MANY_REQUESTS;
 	}
 }
 
@@ -45,7 +57,27 @@ function getLoginErrorMessage(errorCode: LoginErrorCode): string {
 			return "Your account has been disabled.";
 		case LoginErrorCode.LoginDisabled:
 			return "Login is currently disabled.";
+		case LoginErrorCode.RateLimited:
+			return "Too many login attempts. Please try again later.";
 	}
+}
+
+/**
+ * Send a rate limit error response with Retry-After header
+ */
+function sendRateLimitResponse(
+	res: Response<ApiErrorResponse>,
+	rateLimitResult: RateLimitCheckResult,
+): void {
+	const retryAfterSeconds = Math.ceil(
+		(rateLimitResult.retryAfterMs ?? DEFAULT_RETRY_MS) /
+			MILLISECONDS_PER_SECOND,
+	);
+	res.setHeader("Retry-After", String(retryAfterSeconds));
+	res.status(getLoginErrorStatus(LoginErrorCode.RateLimited)).json({
+		success: false,
+		error: getLoginErrorMessage(LoginErrorCode.RateLimited),
+	});
 }
 
 /**
@@ -80,10 +112,26 @@ authRouter.post(
 			return;
 		}
 
+		// Check rate limit BEFORE validating credentials (prevents timing attacks)
+		const rateLimitResult = checkRateLimit(username);
+		if (rateLimitResult.isLocked) {
+			sendRateLimitResponse(res, rateLimitResult);
+			return;
+		}
+
 		// Validate login
 		const result = await validateLogin(username, password);
 
 		if (!result.success || result.user === undefined) {
+			// Record failed login attempt for rate limiting
+			const failureResult = recordFailedLogin(username);
+
+			// Check if this failure triggered a lockout
+			if (failureResult.isLocked) {
+				sendRateLimitResponse(res, failureResult);
+				return;
+			}
+
 			const errorCode = result.errorCode ?? LoginErrorCode.InvalidCredentials;
 			res.status(getLoginErrorStatus(errorCode)).json({
 				success: false,
@@ -91,6 +139,9 @@ authRouter.post(
 			});
 			return;
 		}
+
+		// Successful login - clear rate limit state for this username
+		recordSuccessfulLogin(username);
 
 		// Leave any current meeting from a previous session
 		// This ensures users start fresh and can select a new meeting

--- a/packages/server/src/services/login-rate-limiter.test.ts
+++ b/packages/server/src/services/login-rate-limiter.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Unit tests for login-rate-limiter service
+ *
+ * Tests the per-username rate limiting functionality to prevent brute-force attacks.
+ */
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+	checkRateLimit,
+	recordFailedLogin,
+	recordSuccessfulLogin,
+	cleanupExpiredAttempts,
+	getAttemptState,
+	clearAllState,
+	stopCleanupInterval,
+} from "./login-rate-limiter.js";
+
+describe("login-rate-limiter", () => {
+	beforeEach(() => {
+		// Clear all state before each test
+		clearAllState();
+		// Use fake timers for time-dependent tests
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe("checkRateLimit", () => {
+		it("should return not locked for new username", () => {
+			const result = checkRateLimit("newuser");
+
+			expect(result.isLocked).toBe(false);
+			expect(result.retryAfterMs).toBeNull();
+		});
+
+		it("should return not locked when user has failures but below threshold", () => {
+			// Record 4 failures (below threshold of 5)
+			recordFailedLogin("testuser");
+			recordFailedLogin("testuser");
+			recordFailedLogin("testuser");
+			recordFailedLogin("testuser");
+
+			const result = checkRateLimit("testuser");
+
+			expect(result.isLocked).toBe(false);
+			expect(result.retryAfterMs).toBeNull();
+		});
+
+		it("should return locked when user has reached lockout threshold", () => {
+			// Record 5 failures (triggers tier 1 lockout)
+			for (let i = 0; i < 5; i += 1) {
+				recordFailedLogin("testuser");
+			}
+
+			const result = checkRateLimit("testuser");
+
+			expect(result.isLocked).toBe(true);
+			expect(result.retryAfterMs).toBeGreaterThan(0);
+		});
+
+		it("should normalize username to lowercase", () => {
+			// Record failures with uppercase
+			for (let i = 0; i < 5; i += 1) {
+				recordFailedLogin("TestUser");
+			}
+
+			// Check with lowercase - should be locked
+			const result = checkRateLimit("testuser");
+
+			expect(result.isLocked).toBe(true);
+		});
+
+		it("should trim whitespace from username", () => {
+			// Record failures with whitespace
+			for (let i = 0; i < 5; i += 1) {
+				recordFailedLogin("  testuser  ");
+			}
+
+			// Check without whitespace - should be locked
+			const result = checkRateLimit("testuser");
+
+			expect(result.isLocked).toBe(true);
+		});
+	});
+
+	describe("recordFailedLogin", () => {
+		it("should return not locked for first failure", () => {
+			const result = recordFailedLogin("testuser");
+
+			expect(result.isLocked).toBe(false);
+			expect(result.retryAfterMs).toBeNull();
+		});
+
+		it("should track failure count", () => {
+			recordFailedLogin("testuser");
+			recordFailedLogin("testuser");
+			recordFailedLogin("testuser");
+
+			const state = getAttemptState("testuser");
+
+			expect(state?.failureCount).toBe(3);
+		});
+
+		it("should trigger tier 1 lockout (1 minute) at 5 failures", () => {
+			// Record 4 failures - no lockout yet
+			for (let i = 0; i < 4; i += 1) {
+				const result = recordFailedLogin("testuser");
+				expect(result.isLocked).toBe(false);
+			}
+
+			// 5th failure triggers lockout
+			const result = recordFailedLogin("testuser");
+
+			expect(result.isLocked).toBe(true);
+			// 1 minute = 60000 ms
+			expect(result.retryAfterMs).toBe(60000);
+		});
+
+		it("should trigger tier 2 lockout (5 minutes) at 10 failures", () => {
+			// Record 9 failures
+			for (let i = 0; i < 9; i += 1) {
+				recordFailedLogin("testuser");
+			}
+
+			// Wait for tier 1 lock to expire, then record 10th
+			vi.advanceTimersByTime(60001);
+
+			const result = recordFailedLogin("testuser");
+
+			expect(result.isLocked).toBe(true);
+			// 5 minutes = 300000 ms
+			expect(result.retryAfterMs).toBe(300000);
+		});
+
+		it("should trigger tier 3 lockout (15 minutes) at 15 failures", () => {
+			// Record 14 failures
+			for (let i = 0; i < 14; i += 1) {
+				recordFailedLogin("testuser");
+			}
+
+			// Wait for tier 2 lock to expire, then record 15th
+			vi.advanceTimersByTime(300001);
+
+			const result = recordFailedLogin("testuser");
+
+			expect(result.isLocked).toBe(true);
+			// 15 minutes = 900000 ms
+			expect(result.retryAfterMs).toBe(900000);
+		});
+
+		it("should reset failure count after failure window expires", () => {
+			// Record some failures
+			recordFailedLogin("testuser");
+			recordFailedLogin("testuser");
+			recordFailedLogin("testuser");
+
+			// Advance time past 15 minute window
+			vi.advanceTimersByTime(15 * 60 * 1000 + 1);
+
+			// Record new failure - should reset to 1
+			recordFailedLogin("testuser");
+
+			const state = getAttemptState("testuser");
+
+			expect(state?.failureCount).toBe(1);
+		});
+	});
+
+	describe("recordSuccessfulLogin", () => {
+		it("should clear failure state for username", () => {
+			// Record some failures
+			recordFailedLogin("testuser");
+			recordFailedLogin("testuser");
+			recordFailedLogin("testuser");
+
+			// Successful login
+			recordSuccessfulLogin("testuser");
+
+			const state = getAttemptState("testuser");
+
+			expect(state).toBeUndefined();
+		});
+
+		it("should not throw for username with no previous state", () => {
+			expect(() => {
+				recordSuccessfulLogin("newuser");
+			}).not.toThrow();
+		});
+
+		it("should normalize username when clearing state", () => {
+			// Record failures with lowercase
+			for (let i = 0; i < 3; i += 1) {
+				recordFailedLogin("testuser");
+			}
+
+			// Successful login with uppercase
+			recordSuccessfulLogin("TESTUSER");
+
+			// State should be cleared
+			const state = getAttemptState("testuser");
+
+			expect(state).toBeUndefined();
+		});
+	});
+
+	describe("cleanupExpiredAttempts", () => {
+		it("should remove expired entries", () => {
+			// Record failures for two users
+			recordFailedLogin("user1");
+			recordFailedLogin("user2");
+
+			// Advance time past failure window
+			vi.advanceTimersByTime(15 * 60 * 1000 + 1);
+
+			const cleanedCount = cleanupExpiredAttempts();
+
+			expect(cleanedCount).toBe(2);
+			expect(getAttemptState("user1")).toBeUndefined();
+			expect(getAttemptState("user2")).toBeUndefined();
+		});
+
+		it("should not remove entries within failure window", () => {
+			recordFailedLogin("testuser");
+
+			// Advance time but stay within window
+			vi.advanceTimersByTime(10 * 60 * 1000);
+
+			const cleanedCount = cleanupExpiredAttempts();
+
+			expect(cleanedCount).toBe(0);
+			expect(getAttemptState("testuser")).toBeDefined();
+		});
+
+		it("should not remove entries with active lockout", () => {
+			// Trigger a tier 1 lockout (5 failures = 1 minute lockout)
+			for (let i = 0; i < 5; i += 1) {
+				recordFailedLogin("testuser");
+			}
+
+			// Advance by 30 seconds - lockout still active (1 minute)
+			vi.advanceTimersByTime(30 * 1000);
+
+			const cleanedCount = cleanupExpiredAttempts();
+
+			// Entry should not be cleaned because lockout is still active
+			expect(cleanedCount).toBe(0);
+			expect(getAttemptState("testuser")).toBeDefined();
+		});
+	});
+
+	describe("lockout expiration", () => {
+		it("should unlock after tier 1 lockout expires", () => {
+			// Trigger tier 1 lockout (5 failures = 1 minute)
+			for (let i = 0; i < 5; i += 1) {
+				recordFailedLogin("testuser");
+			}
+
+			// Verify locked
+			expect(checkRateLimit("testuser").isLocked).toBe(true);
+
+			// Advance time past lockout
+			vi.advanceTimersByTime(60001);
+
+			// Should be unlocked now
+			expect(checkRateLimit("testuser").isLocked).toBe(false);
+		});
+
+		it("should clear lockout state when checking after expiry", () => {
+			// Trigger lockout
+			for (let i = 0; i < 5; i += 1) {
+				recordFailedLogin("testuser");
+			}
+
+			const state = getAttemptState("testuser");
+			expect(state?.lockedUntil).not.toBeNull();
+
+			// Advance time past lockout and check
+			vi.advanceTimersByTime(60001);
+			checkRateLimit("testuser");
+
+			// lockedUntil should be cleared
+			const newState = getAttemptState("testuser");
+			expect(newState?.lockedUntil).toBeNull();
+		});
+	});
+
+	describe("cleanup interval", () => {
+		it("should export stopCleanupInterval for graceful shutdown", () => {
+			expect(typeof stopCleanupInterval).toBe("function");
+		});
+	});
+});

--- a/packages/server/src/services/login-rate-limiter.ts
+++ b/packages/server/src/services/login-rate-limiter.ts
@@ -1,0 +1,256 @@
+/**
+ * Login rate limiter service
+ *
+ * Implements per-username rate limiting to prevent brute-force attacks.
+ * Uses in-memory storage (acceptable for convention voting context).
+ */
+import pino from "pino";
+
+const logger = pino({ name: "login-rate-limiter" });
+
+/**
+ * Track login attempt state for a username
+ */
+interface LoginAttemptState {
+	failureCount: number;
+	firstFailureAt: number;
+	lockedUntil: number | null;
+}
+
+/**
+ * Result of checking if a user is rate limited
+ */
+export interface RateLimitCheckResult {
+	isLocked: boolean;
+	retryAfterMs: number | null;
+}
+
+// In-memory store keyed by normalized username (lowercase)
+const loginAttempts = new Map<string, LoginAttemptState>();
+
+// Time constants
+const SECONDS_PER_MINUTE = 60;
+const MILLISECONDS_PER_SECOND = 1000;
+const MINUTES_15 = 15;
+const MINUTES_5 = 5;
+const MINUTES_1 = 1;
+
+// Failure thresholds
+const THRESHOLD_TIER_1 = 5;
+const THRESHOLD_TIER_2 = 10;
+const THRESHOLD_TIER_3 = 15;
+
+// Time window for counting failures (15 minutes)
+const FAILURE_WINDOW_MS =
+	MINUTES_15 * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND;
+
+// Lockout durations
+const LOCKOUT_TIER_1_MS =
+	MINUTES_1 * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND; // 1 minute
+const LOCKOUT_TIER_2_MS =
+	MINUTES_5 * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND; // 5 minutes
+const LOCKOUT_TIER_3_MS =
+	MINUTES_15 * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND; // 15 minutes
+
+// Cleanup interval (run every 5 minutes)
+const CLEANUP_INTERVAL_MS =
+	MINUTES_5 * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND;
+
+// Lockout thresholds - escalating lockout durations
+const LOCKOUT_THRESHOLDS = [
+	{ failures: THRESHOLD_TIER_1, lockoutMs: LOCKOUT_TIER_1_MS },
+	{ failures: THRESHOLD_TIER_2, lockoutMs: LOCKOUT_TIER_2_MS },
+	{ failures: THRESHOLD_TIER_3, lockoutMs: LOCKOUT_TIER_3_MS },
+];
+
+// Initial failure count
+const INITIAL_FAILURE_COUNT = 1;
+
+// No lockout duration
+const NO_LOCKOUT = 0;
+
+/**
+ * Normalize username for consistent lookup
+ */
+function normalizeUsername(username: string): string {
+	return username.toLowerCase().trim();
+}
+
+/**
+ * Get the appropriate lockout duration based on failure count
+ */
+function getLockoutDuration(failureCount: number): number {
+	// Find the highest threshold that applies
+	let lockoutMs = NO_LOCKOUT;
+	for (const { failures, lockoutMs: duration } of LOCKOUT_THRESHOLDS) {
+		if (failureCount >= failures) {
+			lockoutMs = duration;
+		}
+	}
+	return lockoutMs;
+}
+
+/**
+ * Check if a username is currently rate limited
+ *
+ * IMPORTANT: Call this BEFORE validating credentials to prevent timing attacks
+ */
+export function checkRateLimit(username: string): RateLimitCheckResult {
+	const normalizedUsername = normalizeUsername(username);
+	const state = loginAttempts.get(normalizedUsername);
+	const now = Date.now();
+
+	if (state === undefined) {
+		return { isLocked: false, retryAfterMs: null };
+	}
+
+	// Check if currently locked
+	if (state.lockedUntil !== null && now < state.lockedUntil) {
+		const retryAfterMs = state.lockedUntil - now;
+		return { isLocked: true, retryAfterMs };
+	}
+
+	// Lock has expired - clear it
+	if (state.lockedUntil !== null && now >= state.lockedUntil) {
+		state.lockedUntil = null;
+	}
+
+	return { isLocked: false, retryAfterMs: null };
+}
+
+/**
+ * Record a failed login attempt for a username
+ *
+ * Returns the rate limit status after recording the failure
+ */
+export function recordFailedLogin(username: string): RateLimitCheckResult {
+	const normalizedUsername = normalizeUsername(username);
+	const now = Date.now();
+
+	let state = loginAttempts.get(normalizedUsername);
+
+	if (state === undefined) {
+		// First failure for this username
+		state = {
+			failureCount: INITIAL_FAILURE_COUNT,
+			firstFailureAt: now,
+			lockedUntil: null,
+		};
+		loginAttempts.set(normalizedUsername, state);
+		logger.debug(
+			{ username: normalizedUsername },
+			"First failed login attempt",
+		);
+		return { isLocked: false, retryAfterMs: null };
+	}
+
+	// Check if we're outside the failure window - reset if so
+	if (now - state.firstFailureAt > FAILURE_WINDOW_MS) {
+		state.failureCount = INITIAL_FAILURE_COUNT;
+		state.firstFailureAt = now;
+		state.lockedUntil = null;
+		logger.debug(
+			{ username: normalizedUsername },
+			"Reset failure count (outside window)",
+		);
+		return { isLocked: false, retryAfterMs: null };
+	}
+
+	// Increment failure count
+	state.failureCount += INITIAL_FAILURE_COUNT;
+
+	// Check if we need to apply a lockout
+	const lockoutMs = getLockoutDuration(state.failureCount);
+	if (lockoutMs > NO_LOCKOUT) {
+		state.lockedUntil = now + lockoutMs;
+		logger.warn(
+			{
+				username: normalizedUsername,
+				failureCount: state.failureCount,
+				lockoutMs,
+			},
+			"Username locked due to too many failed attempts",
+		);
+		return { isLocked: true, retryAfterMs: lockoutMs };
+	}
+
+	logger.debug(
+		{ username: normalizedUsername, failureCount: state.failureCount },
+		"Failed login attempt recorded",
+	);
+	return { isLocked: false, retryAfterMs: null };
+}
+
+/**
+ * Record a successful login - resets the failure count
+ */
+export function recordSuccessfulLogin(username: string): void {
+	const normalizedUsername = normalizeUsername(username);
+	const state = loginAttempts.get(normalizedUsername);
+
+	if (state !== undefined) {
+		logger.debug(
+			{
+				username: normalizedUsername,
+				previousFailures: state.failureCount,
+			},
+			"Successful login - resetting failure count",
+		);
+		loginAttempts.delete(normalizedUsername);
+	}
+}
+
+/**
+ * Clean up expired entries to prevent memory leaks
+ *
+ * Removes entries where:
+ * - The failure window has expired AND no active lock
+ * - The lock has expired
+ */
+export function cleanupExpiredAttempts(): number {
+	const now = Date.now();
+	let cleanedCount = 0;
+
+	for (const [username, state] of loginAttempts.entries()) {
+		const windowExpired = now - state.firstFailureAt > FAILURE_WINDOW_MS;
+		const lockExpired = state.lockedUntil === null || now >= state.lockedUntil;
+
+		if (windowExpired && lockExpired) {
+			loginAttempts.delete(username);
+			cleanedCount += INITIAL_FAILURE_COUNT;
+		}
+	}
+
+	if (cleanedCount > NO_LOCKOUT) {
+		logger.debug({ cleanedCount }, "Cleaned up expired login attempts");
+	}
+
+	return cleanedCount;
+}
+
+/**
+ * Get current state for testing/debugging purposes
+ */
+export function getAttemptState(
+	username: string,
+): LoginAttemptState | undefined {
+	return loginAttempts.get(normalizeUsername(username));
+}
+
+/**
+ * Clear all state - for testing purposes only
+ */
+export function clearAllState(): void {
+	loginAttempts.clear();
+}
+
+// Start periodic cleanup
+const cleanupInterval = setInterval(
+	cleanupExpiredAttempts,
+	CLEANUP_INTERVAL_MS,
+);
+
+// Allow cleanup interval to be cleared for graceful shutdown
+export function stopCleanupInterval(): void {
+	clearInterval(cleanupInterval);
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -900,6 +900,7 @@ export enum LoginErrorCode {
 	AccountDisabled = "ACCOUNT_DISABLED",
 	NoPasswordSet = "NO_PASSWORD_SET",
 	LoginDisabled = "LOGIN_DISABLED",
+	RateLimited = "RATE_LIMITED",
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements per-username rate limiting to prevent brute-force login attacks
- Uses escalating lockout thresholds (5 failures → 1 min, 10 → 5 min, 15+ → 15 min)
- Returns HTTP 429 Too Many Requests with Retry-After header when rate limited
- Checks rate limit BEFORE credential validation to prevent timing attacks

## Changes
- Added `RateLimited` error code to `LoginErrorCode` enum in shared types
- Created new `login-rate-limiter.ts` service with in-memory storage
- Integrated rate limiter into auth.ts login endpoint
- Added 20 unit tests covering all rate limiting scenarios

## Test plan
- [x] Run `npm run test:unit` - all 28 tests pass
- [x] Run `npm run lint` - no errors
- [ ] Manual testing: attempt 5+ failed logins and verify lockout
- [ ] Manual testing: verify successful login clears rate limit state
- [ ] Manual testing: verify Retry-After header is present in 429 response

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)