### PR TITLE
Fix motion results to not show winner for ties or zero votes (Issue #122)

### DIFF
--- a/packages/server/src/services/meeting-service.ts
+++ b/packages/server/src/services/meeting-service.ts
@@ -46,6 +46,7 @@ const SORT_ORDER_INCREMENT = 1;
 // Vote statistics constants
 const ZERO_VOTES = 0;
 const PERCENTAGE_MULTIPLIER = 100;
+const NO_CUTOFF = -1;
 
 // Status transitions (forward-only)
 const VALID_STATUS_TRANSITIONS: Record<MotionStatus, MotionStatus[]> = {
@@ -1686,26 +1687,37 @@ export async function getMotionDetailedResults(
 	);
 
 	// Step 5: Calculate percentages and determine winners
-	const choiceResults: ChoiceResult[] = choiceResultsQuery.rows.map(
-		(row, index) => {
-			const voteCount = parseInt(row.vote_count, DECIMAL_RADIX);
-			const percentage =
-				totalVotesForChoices > ZERO_VOTES
-					? (voteCount / totalVotesForChoices) * PERCENTAGE_MULTIPLIER
-					: ZERO_VOTES;
+	// Find the cutoff vote count (the vote count at position selectionCount)
+	// A choice is only a winner if it has MORE votes than this cutoff (handles ties)
+	// and has at least one vote (handles zero-vote scenarios)
+	const cutoffVoteCount =
+		choiceResultsQuery.rows.length > motion.selectionCount
+			? parseInt(
+					choiceResultsQuery.rows[motion.selectionCount].vote_count,
+					DECIMAL_RADIX,
+				)
+			: NO_CUTOFF;
 
-			// Winner determination: top selection_count choices by vote count
-			const isWinner = index < motion.selectionCount;
+	const choiceResults: ChoiceResult[] = choiceResultsQuery.rows.map((row) => {
+		const voteCount = parseInt(row.vote_count, DECIMAL_RADIX);
+		const percentage =
+			totalVotesForChoices > ZERO_VOTES
+				? (voteCount / totalVotesForChoices) * PERCENTAGE_MULTIPLIER
+				: ZERO_VOTES;
 
-			return {
-				choiceId: row.choice_id,
-				choiceName: row.choice_name,
-				voteCount,
-				percentage,
-				isWinner,
-			};
-		},
-	);
+		// Winner determination:
+		// 1. Must have at least one vote
+		// 2. Must have strictly more votes than the cutoff (handles ties at boundary)
+		const isWinner = voteCount > ZERO_VOTES && voteCount > cutoffVoteCount;
+
+		return {
+			choiceId: row.choice_id,
+			choiceName: row.choice_name,
+			voteCount,
+			percentage,
+			isWinner,
+		};
+	});
 
 	// Step 6: Calculate participation and abstention percentages
 	const participationRate =

--- a/packages/server/src/services/watcher-service.ts
+++ b/packages/server/src/services/watcher-service.ts
@@ -33,6 +33,10 @@ const PAGE_OFFSET_ADJUSTMENT = 1;
 // Number parsing
 const DECIMAL_RADIX = 10;
 
+// Winner determination constants
+const ZERO_VOTES = 0;
+const NO_CUTOFF = -1;
+
 /**
  * Check whether a user is authorized to view a specific meeting as a watcher,
  * i.e. they are in the meeting's watcher_pool.
@@ -355,14 +359,28 @@ async function getWatcherMotionResultInternal(
 		{ motionId },
 	);
 
-	// Determine winners (top selection_count choices by vote count)
+	// Determine winners:
+	// Find the cutoff vote count (the vote count at position selectionCount)
+	// A choice is only a winner if it has MORE votes than this cutoff (handles ties)
+	// and has at least one vote (handles zero-vote scenarios)
+	const cutoffVoteCount =
+		choiceResultsQuery.rows.length > selectionCount
+			? parseInt(
+					choiceResultsQuery.rows[selectionCount].vote_count,
+					DECIMAL_RADIX,
+				)
+			: NO_CUTOFF;
+
 	const choiceTallies: WatcherChoiceTally[] = choiceResultsQuery.rows.map(
-		(row, index) => ({
-			choiceId: row.choice_id,
-			choiceName: row.choice_name,
-			voteCount: parseInt(row.vote_count, DECIMAL_RADIX),
-			isWinner: index < selectionCount,
-		}),
+		(row) => {
+			const voteCount = parseInt(row.vote_count, DECIMAL_RADIX);
+			return {
+				choiceId: row.choice_id,
+				choiceName: row.choice_name,
+				voteCount,
+				isWinner: voteCount > ZERO_VOTES && voteCount > cutoffVoteCount,
+			};
+		},
 	);
 
 	return {


### PR DESCRIPTION
## Summary
- Fixes winner determination logic to properly handle tie scenarios
- Prevents marking choices with zero votes as winners
- Updates both admin (`meeting-service.ts`) and watcher (`watcher-service.ts`) endpoints

## Problem
The motion results report was incorrectly showing winners when:
1. There was a tie at the selection boundary (e.g., 2 choices tied for 2nd place when selecting top 2)
2. A choice had zero votes but was marked as winner due to position

## Solution
Changed winner determination from simple index check:
```typescript
// Before (buggy)
const isWinner = index < selectionCount;
```

To cutoff-based logic:
```typescript
// After (fixed)
const cutoffVoteCount = rows.length > selectionCount 
  ? rows[selectionCount].voteCount : -1;
const isWinner = voteCount > 0 && voteCount > cutoffVoteCount;
```

## Examples
| selectionCount | Votes (sorted) | Winners | Reason |
|----------------|----------------|---------|--------|
| 2 | [10, 8, 5] | 10, 8 | Clear top 2 |
| 2 | [10, 5, 5] | 10 only | 5s tie at cutoff |
| 1 | [5, 5, 3] | None | Tie for 1st |
| 2 | [5, 5, 3] | 5, 5 | Both clearly in top 2 |
| 2 | [0, 0, 0] | None | No votes cast |

## Test plan
- [x] Run `npm run lint` - passes
- [x] Run `npm run test:unit` - 28 tests pass
- [ ] Manual test: Create motion with tied votes and verify no winner shown at boundary
- [ ] Manual test: Create motion with zero votes and verify no winner shown

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)