### PR TITLE
Add configurable quorum percentage per meeting (Issue #128)

### DIFF
--- a/packages/client/src/views/admin/MeetingCreate.vue
+++ b/packages/client/src/views/admin/MeetingCreate.vue
@@ -22,12 +22,15 @@ const quorumEligiblePools = computed(() =>
 	),
 );
 
+const DEFAULT_QUORUM_PERCENTAGE = 50;
+
 const formData = ref({
 	name: EMPTY_STRING,
 	description: EMPTY_STRING,
 	startDate: EMPTY_STRING,
 	endDate: EMPTY_STRING,
 	quorumVotingPoolId: EMPTY_STRING,
+	quorumPercentage: DEFAULT_QUORUM_PERCENTAGE,
 });
 
 const saving = ref(false);
@@ -55,6 +58,7 @@ interface FormDataType {
 	startDate: string;
 	endDate: string;
 	quorumVotingPoolId: string;
+	quorumPercentage: number;
 }
 
 function validateFormData(data: FormDataType): string | null {
@@ -101,6 +105,7 @@ async function handleSubmit(): Promise<void> {
 				formData.value.quorumVotingPoolId,
 				10,
 			),
+			quorumPercentage: formData.value.quorumPercentage,
 			...(formData.value.description.trim() !== EMPTY_STRING && {
 				description: formData.value.description.trim(),
 			}),
@@ -197,6 +202,25 @@ onMounted(() => {
 				<p class="field-description">
 					The pool used to determine quorum for this meeting. Only pools with
 					"Voter" type or unspecified type can be used as quorum pools.
+				</p>
+			</div>
+
+			<div class="form-group">
+				<label for="quorumPercentage">
+					Quorum Percentage <span class="required">*</span>
+				</label>
+				<input
+					id="quorumPercentage"
+					v-model.number="formData.quorumPercentage"
+					type="number"
+					min="0"
+					max="100"
+					step="1"
+					required
+				/>
+				<p class="field-description">
+					Percentage of eligible voters required to establish quorum (0-100).
+					Default is 50%.
 				</p>
 			</div>
 

--- a/packages/client/src/views/admin/MeetingEdit.vue
+++ b/packages/client/src/views/admin/MeetingEdit.vue
@@ -69,12 +69,15 @@ const meetingAdminEligiblePools = computed(() =>
 	pools.value.filter((pool) => pool.poolType === PoolType.MeetingAdmin),
 );
 
+const DEFAULT_QUORUM_PERCENTAGE = 50;
+
 const formData = ref({
 	name: EMPTY_STRING,
 	description: EMPTY_STRING,
 	startDate: EMPTY_STRING,
 	endDate: EMPTY_STRING,
 	quorumVotingPoolId: EMPTY_STRING,
+	quorumPercentage: DEFAULT_QUORUM_PERCENTAGE,
 	watcherPoolId: EMPTY_STRING,
 	meetingAdminPoolId: EMPTY_STRING,
 });
@@ -191,6 +194,7 @@ async function loadMeeting(): Promise<void> {
 				startDate: formatDateForInput(meeting.startDate),
 				endDate: formatDateForInput(meeting.endDate),
 				quorumVotingPoolId: String(meeting.quorumVotingPoolId),
+				quorumPercentage: meeting.quorumPercentage,
 				watcherPoolId:
 					meeting.watcherPoolId === null
 						? EMPTY_STRING
@@ -469,6 +473,7 @@ interface FormDataType {
 	startDate: string;
 	endDate: string;
 	quorumVotingPoolId: string;
+	quorumPercentage: number;
 	watcherPoolId: string;
 	meetingAdminPoolId: string;
 }
@@ -519,6 +524,7 @@ async function handleSubmit(): Promise<void> {
 				formData.value.quorumVotingPoolId,
 				DECIMAL_RADIX,
 			),
+			quorumPercentage: formData.value.quorumPercentage,
 			description:
 				trimmedDescription === EMPTY_STRING ? undefined : trimmedDescription,
 			watcherPoolId:
@@ -630,6 +636,24 @@ onMounted(() => {
 				<p class="field-description">
 					Only pools with "Voter" type or unspecified type can be used as quorum
 					pools.
+				</p>
+			</div>
+
+			<div class="form-group">
+				<label for="quorumPercentage">
+					Quorum Percentage <span class="required">*</span>
+				</label>
+				<input
+					id="quorumPercentage"
+					v-model.number="formData.quorumPercentage"
+					type="number"
+					min="0"
+					max="100"
+					step="1"
+					required
+				/>
+				<p class="field-description">
+					Percentage of eligible voters required to establish quorum (0-100).
 				</p>
 			</div>
 

--- a/packages/client/src/views/admin/MeetingQuorum.vue
+++ b/packages/client/src/views/admin/MeetingQuorum.vue
@@ -36,6 +36,8 @@ let refreshInterval: ReturnType<typeof setInterval> | null = null;
 
 const isQuorumCalled = computed(() => report.value?.quorumCalledAt !== null);
 
+const hasQuorum = computed(() => report.value?.hasQuorum ?? false);
+
 const formattedPercentage = computed(() => {
 	if (report.value === null) return "0.0";
 	return report.value.activeVoterPercentage.toFixed(PERCENTAGE_PRECISION);
@@ -195,6 +197,12 @@ onUnmounted(() => {
 			<div class="meeting-info">
 				<h3>{{ report.meetingName }}</h3>
 				<p class="pool-info">Quorum Pool: {{ report.quorumPoolName }}</p>
+				<p class="quorum-requirement">
+					Quorum Requirement: {{ report.quorumPercentage }}% ({{
+						report.votersNeededForQuorum
+					}}
+					voters needed)
+				</p>
 			</div>
 
 			<div class="quorum-stats">
@@ -211,6 +219,23 @@ onUnmounted(() => {
 				<div class="stat-card percentage">
 					<div class="stat-value">{{ formattedPercentage }}%</div>
 					<div class="stat-label">Participation</div>
+				</div>
+			</div>
+
+			<!-- Quorum Achievement Indicator -->
+			<div class="quorum-achievement" :class="{ achieved: hasQuorum }">
+				<div v-if="hasQuorum" class="achievement-content achieved">
+					<span class="achievement-icon">&#10003;</span>
+					<span class="achievement-text">Quorum Achieved</span>
+					<span class="achievement-detail">Voting on motions may proceed</span>
+				</div>
+				<div v-else class="achievement-content not-achieved">
+					<span class="achievement-icon">&#10007;</span>
+					<span class="achievement-text">Quorum Not Met</span>
+					<span class="achievement-detail"
+						>{{ report.votersNeededForQuorum - report.activeVoterCount }} more
+						voter(s) needed</span
+					>
 				</div>
 			</div>
 
@@ -328,8 +353,14 @@ h2 {
 }
 
 .pool-info {
-	margin: 0;
+	margin: 0 0 0.25rem 0;
 	color: #666;
+}
+
+.quorum-requirement {
+	margin: 0;
+	color: #1976d2;
+	font-weight: 500;
 }
 
 .quorum-stats {
@@ -337,6 +368,61 @@ h2 {
 	grid-template-columns: repeat(3, 1fr);
 	gap: 1rem;
 	margin-bottom: 1.5rem;
+}
+
+.quorum-achievement {
+	border-radius: 8px;
+	padding: 1.25rem;
+	margin-bottom: 1.5rem;
+	text-align: center;
+}
+
+.quorum-achievement.achieved {
+	background: #e8f5e9;
+	border: 2px solid #4caf50;
+}
+
+.quorum-achievement:not(.achieved) {
+	background: #fff3e0;
+	border: 2px solid #ff9800;
+}
+
+.achievement-content {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.achievement-icon {
+	font-size: 2rem;
+	font-weight: bold;
+}
+
+.achievement-content.achieved .achievement-icon {
+	color: #2e7d32;
+}
+
+.achievement-content.not-achieved .achievement-icon {
+	color: #e65100;
+}
+
+.achievement-text {
+	font-size: 1.25rem;
+	font-weight: 600;
+}
+
+.achievement-content.achieved .achievement-text {
+	color: #2e7d32;
+}
+
+.achievement-content.not-achieved .achievement-text {
+	color: #e65100;
+}
+
+.achievement-detail {
+	font-size: 0.875rem;
+	color: #666;
 }
 
 .stat-card {

--- a/packages/client/src/views/admin/ProjectorControl.vue
+++ b/packages/client/src/views/admin/ProjectorControl.vue
@@ -768,18 +768,22 @@ onUnmounted(() => {
 							<h4>{{ selectedMeeting.name }}</h4>
 							<div
 								class="quorum-status"
-								:class="{ achieved: quorum.activeVoterPercentage >= 50 }"
+								:class="{ achieved: quorum.hasQuorum }"
 							>
 								{{
-									quorum.activeVoterPercentage >= 50
-										? "Quorum Achieved"
-										: "Quorum Not Reached"
+									quorum.hasQuorum ? "Quorum Achieved" : "Quorum Not Reached"
 								}}
 							</div>
 							<div class="quorum-numbers">
 								<div class="stat">
 									<span class="value">{{ quorum.activeVoterCount }}</span>
 									<span class="label">Present</span>
+								</div>
+								<div class="stat">
+									<span class="value">{{ quorum.votersNeededForQuorum }}</span>
+									<span class="label"
+										>Required ({{ quorum.quorumPercentage }}%)</span
+									>
 								</div>
 								<div class="stat">
 									<span class="value">{{ quorum.totalEligibleVoters }}</span>

--- a/packages/client/src/views/admin/ProjectorDisplay.vue
+++ b/packages/client/src/views/admin/ProjectorDisplay.vue
@@ -285,15 +285,8 @@ onUnmounted(() => {
 			<div v-if="meeting !== null && quorum !== null" class="quorum-content">
 				<h1>{{ meeting.name }}</h1>
 				<div class="quorum-display">
-					<div
-						class="quorum-status"
-						:class="{ achieved: quorum.activeVoterPercentage >= 50 }"
-					>
-						{{
-							quorum.activeVoterPercentage >= 50
-								? "Quorum Achieved"
-								: "Quorum Not Reached"
-						}}
+					<div class="quorum-status" :class="{ achieved: quorum.hasQuorum }">
+						{{ quorum.hasQuorum ? "Quorum Achieved" : "Quorum Not Reached" }}
 					</div>
 					<div class="quorum-numbers">
 						<div class="stat">
@@ -301,10 +294,10 @@ onUnmounted(() => {
 							<span class="label">Present</span>
 						</div>
 						<div class="stat">
-							<span class="value">{{
-								Math.ceil(quorum.totalEligibleVoters / 2 + 1)
-							}}</span>
-							<span class="label">Required</span>
+							<span class="value">{{ quorum.votersNeededForQuorum }}</span>
+							<span class="label"
+								>Required ({{ quorum.quorumPercentage }}%)</span
+							>
 						</div>
 						<div class="stat">
 							<span class="value">{{ quorum.totalEligibleVoters }}</span>

--- a/packages/client/src/views/voter/MeetingSelection.vue
+++ b/packages/client/src/views/voter/MeetingSelection.vue
@@ -212,7 +212,6 @@ onMounted((): void => {
 							{{ meeting.description }}
 						</p>
 						<div class="meeting-meta">
-							<span class="pool-badge">{{ meeting.quorumVotingPoolName }}</span>
 							<span class="date-range">
 								{{ formatDate(meeting.startDate) }} -
 								{{ formatDate(meeting.endDate) }}
@@ -267,9 +266,6 @@ onMounted((): void => {
 						<p v-if="meeting.description" class="description">
 							{{ meeting.description }}
 						</p>
-						<div class="meeting-meta">
-							<span class="pool-badge">{{ meeting.quorumVotingPoolName }}</span>
-						</div>
 						<div class="upcoming-schedule">
 							<div class="schedule-row">
 								<span class="schedule-label">Starts:</span>

--- a/packages/client/src/views/watcher/WatcherQuorumReport.vue
+++ b/packages/client/src/views/watcher/WatcherQuorumReport.vue
@@ -34,6 +34,8 @@ let refreshInterval: ReturnType<typeof setInterval> | null = null;
 
 const isQuorumCalled = computed(() => report.value?.quorumCalledAt !== null);
 
+const hasQuorum = computed(() => report.value?.hasQuorum ?? false);
+
 const formattedPercentage = computed(() => {
 	if (report.value === null) return "0.0";
 	return report.value.activeVoterPercentage.toFixed(PERCENTAGE_PRECISION);
@@ -146,6 +148,12 @@ onUnmounted(() => {
 			<div class="meeting-info">
 				<h3>{{ report.meetingName }}</h3>
 				<p class="pool-info">Quorum Pool: {{ report.quorumPoolName }}</p>
+				<p class="quorum-requirement">
+					Quorum Requirement: {{ report.quorumPercentage }}% ({{
+						report.votersNeededForQuorum
+					}}
+					voters needed)
+				</p>
 			</div>
 
 			<div class="quorum-stats">
@@ -162,6 +170,23 @@ onUnmounted(() => {
 				<div class="stat-card percentage">
 					<div class="stat-value">{{ formattedPercentage }}%</div>
 					<div class="stat-label">Participation</div>
+				</div>
+			</div>
+
+			<!-- Quorum Achievement Indicator -->
+			<div class="quorum-achievement" :class="{ achieved: hasQuorum }">
+				<div v-if="hasQuorum" class="achievement-content achieved">
+					<span class="achievement-icon">&#10003;</span>
+					<span class="achievement-text">Quorum Achieved</span>
+					<span class="achievement-detail">Voting on motions may proceed</span>
+				</div>
+				<div v-else class="achievement-content not-achieved">
+					<span class="achievement-icon">&#10007;</span>
+					<span class="achievement-text">Quorum Not Met</span>
+					<span class="achievement-detail"
+						>{{ report.votersNeededForQuorum - report.activeVoterCount }} more
+						voter(s) needed</span
+					>
 				</div>
 			</div>
 
@@ -267,8 +292,14 @@ h2 {
 }
 
 .pool-info {
-	margin: 0;
+	margin: 0 0 0.25rem 0;
 	color: #666;
+}
+
+.quorum-requirement {
+	margin: 0;
+	color: #1976d2;
+	font-weight: 500;
 }
 
 .quorum-stats {
@@ -314,6 +345,61 @@ h2 {
 	font-size: 0.875rem;
 	color: #666;
 	margin-top: 0.5rem;
+}
+
+.quorum-achievement {
+	border-radius: 8px;
+	padding: 1.25rem;
+	margin-bottom: 1.5rem;
+	text-align: center;
+}
+
+.quorum-achievement.achieved {
+	background: #e8f5e9;
+	border: 2px solid #4caf50;
+}
+
+.quorum-achievement:not(.achieved) {
+	background: #fff3e0;
+	border: 2px solid #ff9800;
+}
+
+.achievement-content {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.achievement-icon {
+	font-size: 2rem;
+	font-weight: bold;
+}
+
+.achievement-content.achieved .achievement-icon {
+	color: #2e7d32;
+}
+
+.achievement-content.not-achieved .achievement-icon {
+	color: #e65100;
+}
+
+.achievement-text {
+	font-size: 1.25rem;
+	font-weight: 600;
+}
+
+.achievement-content.achieved .achievement-text {
+	color: #2e7d32;
+}
+
+.achievement-content.not-achieved .achievement-text {
+	color: #e65100;
+}
+
+.achievement-detail {
+	font-size: 0.875rem;
+	color: #666;
 }
 
 .quorum-status {

--- a/packages/server/src/database/migrations/0020-add-quorum-percentage.sql
+++ b/packages/server/src/database/migrations/0020-add-quorum-percentage.sql
@@ -1,0 +1,20 @@
+-- Migration: Add quorum percentage configuration to meetings
+-- Issue #128: Configurable quorum percentage per meeting
+
+-- Add quorum_percentage column to meetings table
+-- Default to 50 for existing meetings (maintains current behavior)
+ALTER TABLE meetings
+ADD COLUMN quorum_percentage DECIMAL(5,2) NOT NULL DEFAULT 50.00;
+
+-- Add quorum_eligible_snapshot column
+-- Stores the eligible voter count when quorum is called (frozen value)
+-- This ensures quorum reports don't change if pool membership changes after quorum is called
+ALTER TABLE meetings
+ADD COLUMN quorum_eligible_snapshot INTEGER NULL;
+
+-- Add comments for documentation
+COMMENT ON COLUMN meetings.quorum_percentage IS
+  'Percentage of quorum pool members required to achieve quorum (0-100)';
+
+COMMENT ON COLUMN meetings.quorum_eligible_snapshot IS
+  'Snapshot of eligible voter count when quorum was called. NULL if quorum not yet called.';

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -1553,6 +1553,7 @@ adminRouter.post(
 				startDate: request.startDate,
 				endDate: request.endDate,
 				quorumVotingPoolId: request.quorumVotingPoolId,
+				quorumPercentage: request.quorumPercentage,
 				watcherPoolId: request.watcherPoolId,
 				meetingAdminPoolId: request.meetingAdminPoolId,
 				description: request.description,

--- a/packages/server/src/services/meeting-participant-service.ts
+++ b/packages/server/src/services/meeting-participant-service.ts
@@ -94,6 +94,8 @@ export async function getCurrentMeetingInfo(
 		start_date: Date;
 		end_date: Date;
 		quorum_voting_pool_id: number;
+		quorum_percentage: string;
+		quorum_eligible_snapshot: number | null;
 		watcher_pool_id: number | null;
 		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
@@ -129,6 +131,8 @@ export async function getCurrentMeetingInfo(
 		startDate: row.start_date,
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
+		quorumPercentage: parseFloat(row.quorum_percentage),
+		quorumEligibleSnapshot: row.quorum_eligible_snapshot,
 		watcherPoolId: row.watcher_pool_id,
 		meetingAdminPoolId: row.meeting_admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,
@@ -248,6 +252,8 @@ export async function joinMeetingAsVoter(
 		start_date: Date;
 		end_date: Date;
 		quorum_voting_pool_id: number;
+		quorum_percentage: string;
+		quorum_eligible_snapshot: number | null;
 		watcher_pool_id: number | null;
 		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
@@ -342,6 +348,8 @@ export async function joinMeetingAsVoter(
 		startDate: meetingRow.start_date,
 		endDate: meetingRow.end_date,
 		quorumVotingPoolId: meetingRow.quorum_voting_pool_id,
+		quorumPercentage: parseFloat(meetingRow.quorum_percentage),
+		quorumEligibleSnapshot: meetingRow.quorum_eligible_snapshot,
 		watcherPoolId: meetingRow.watcher_pool_id,
 		meetingAdminPoolId: meetingRow.meeting_admin_pool_id,
 		quorumCalledAt: meetingRow.quorum_called_at,
@@ -544,6 +552,8 @@ export async function joinMeetingAsWatcher(
 		start_date: Date;
 		end_date: Date;
 		quorum_voting_pool_id: number;
+		quorum_percentage: string;
+		quorum_eligible_snapshot: number | null;
 		watcher_pool_id: number | null;
 		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
@@ -620,6 +630,8 @@ export async function joinMeetingAsWatcher(
 		startDate: meetingRow.start_date,
 		endDate: meetingRow.end_date,
 		quorumVotingPoolId: meetingRow.quorum_voting_pool_id,
+		quorumPercentage: parseFloat(meetingRow.quorum_percentage),
+		quorumEligibleSnapshot: meetingRow.quorum_eligible_snapshot,
 		watcherPoolId: meetingRow.watcher_pool_id,
 		meetingAdminPoolId: meetingRow.meeting_admin_pool_id,
 		quorumCalledAt: meetingRow.quorum_called_at,
@@ -750,6 +762,8 @@ export async function joinMeetingAsAdmin(
 		start_date: Date;
 		end_date: Date;
 		quorum_voting_pool_id: number;
+		quorum_percentage: string;
+		quorum_eligible_snapshot: number | null;
 		watcher_pool_id: number | null;
 		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
@@ -818,6 +832,8 @@ export async function joinMeetingAsAdmin(
 		startDate: meetingRow.start_date,
 		endDate: meetingRow.end_date,
 		quorumVotingPoolId: meetingRow.quorum_voting_pool_id,
+		quorumPercentage: parseFloat(meetingRow.quorum_percentage),
+		quorumEligibleSnapshot: meetingRow.quorum_eligible_snapshot,
 		watcherPoolId: meetingRow.watcher_pool_id,
 		meetingAdminPoolId: meetingRow.meeting_admin_pool_id,
 		quorumCalledAt: meetingRow.quorum_called_at,

--- a/packages/server/src/services/meeting-service.ts
+++ b/packages/server/src/services/meeting-service.ts
@@ -48,6 +48,9 @@ const ZERO_VOTES = 0;
 const PERCENTAGE_MULTIPLIER = 100;
 const NO_CUTOFF = -1;
 
+// Quorum defaults
+const DEFAULT_QUORUM_PERCENTAGE = 50;
+
 // Status transitions (forward-only)
 const VALID_STATUS_TRANSITIONS: Record<MotionStatus, MotionStatus[]> = {
 	[MotionStatus.NotYetStarted]: [MotionStatus.VotingActive],
@@ -129,13 +132,23 @@ async function autoCreateMeetingPools(meetingName: string): Promise<{
 export async function createMeeting(
 	request: CreateMeetingRequest,
 ): Promise<Meeting> {
-	const { name, description, startDate, endDate, quorumVotingPoolId } = request;
+	const {
+		name,
+		description,
+		startDate,
+		endDate,
+		quorumVotingPoolId,
+		quorumPercentage,
+	} = request;
 
 	// Verify quorum pool exists
 	await verifyPoolExists(quorumVotingPoolId, "Pool");
 
 	// Auto-create watcher and meeting admin pools
 	const { watcherPool, meetingAdminPool } = await autoCreateMeetingPools(name);
+
+	// Use provided quorum percentage or default to 50%
+	const finalQuorumPercentage = quorumPercentage ?? DEFAULT_QUORUM_PERCENTAGE;
 
 	const result = await db.query<{
 		id: number;
@@ -144,14 +157,16 @@ export async function createMeeting(
 		start_date: Date;
 		end_date: Date;
 		quorum_voting_pool_id: number;
+		quorum_percentage: string;
+		quorum_eligible_snapshot: number | null;
 		watcher_pool_id: number | null;
 		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
 		created_at: Date;
 		updated_at: Date;
 	}>(
-		`INSERT INTO meetings (name, description, start_date, end_date, quorum_voting_pool_id, watcher_pool_id, meeting_admin_pool_id)
-		 VALUES (:name, :description, :startDate, :endDate, :quorumVotingPoolId, :watcherPoolId, :meetingAdminPoolId)
+		`INSERT INTO meetings (name, description, start_date, end_date, quorum_voting_pool_id, quorum_percentage, watcher_pool_id, meeting_admin_pool_id)
+		 VALUES (:name, :description, :startDate, :endDate, :quorumVotingPoolId, :quorumPercentage, :watcherPoolId, :meetingAdminPoolId)
 		 RETURNING *`,
 		{
 			name,
@@ -159,6 +174,7 @@ export async function createMeeting(
 			startDate,
 			endDate,
 			quorumVotingPoolId,
+			quorumPercentage: finalQuorumPercentage,
 			watcherPoolId: watcherPool.id,
 			meetingAdminPoolId: meetingAdminPool.id,
 		},
@@ -182,6 +198,8 @@ export async function createMeeting(
 		startDate: row.start_date,
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
+		quorumPercentage: parseFloat(row.quorum_percentage),
+		quorumEligibleSnapshot: row.quorum_eligible_snapshot,
 		watcherPoolId: row.watcher_pool_id,
 		meetingAdminPoolId: row.meeting_admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,
@@ -204,6 +222,8 @@ export async function getMeetingById(
 		start_date: Date;
 		end_date: Date;
 		quorum_voting_pool_id: number;
+		quorum_percentage: string;
+		quorum_eligible_snapshot: number | null;
 		watcher_pool_id: number | null;
 		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
@@ -243,6 +263,8 @@ export async function getMeetingById(
 		startDate: row.start_date,
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
+		quorumPercentage: parseFloat(row.quorum_percentage),
+		quorumEligibleSnapshot: row.quorum_eligible_snapshot,
 		watcherPoolId: row.watcher_pool_id,
 		meetingAdminPoolId: row.meeting_admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,
@@ -278,6 +300,8 @@ export async function listMeetings(
 		start_date: Date;
 		end_date: Date;
 		quorum_voting_pool_id: number;
+		quorum_percentage: string;
+		quorum_eligible_snapshot: number | null;
 		watcher_pool_id: number | null;
 		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
@@ -307,6 +331,8 @@ export async function listMeetings(
 		startDate: row.start_date,
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
+		quorumPercentage: parseFloat(row.quorum_percentage),
+		quorumEligibleSnapshot: row.quorum_eligible_snapshot,
 		watcherPoolId: row.watcher_pool_id,
 		meetingAdminPoolId: row.meeting_admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,
@@ -348,6 +374,8 @@ export async function listMeetingsForMeetingAdmin(
 		start_date: Date;
 		end_date: Date;
 		quorum_voting_pool_id: number;
+		quorum_percentage: string;
+		quorum_eligible_snapshot: number | null;
 		watcher_pool_id: number | null;
 		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
@@ -379,6 +407,8 @@ export async function listMeetingsForMeetingAdmin(
 		startDate: row.start_date,
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
+		quorumPercentage: parseFloat(row.quorum_percentage),
+		quorumEligibleSnapshot: row.quorum_eligible_snapshot,
 		watcherPoolId: row.watcher_pool_id,
 		meetingAdminPoolId: row.meeting_admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,
@@ -395,6 +425,7 @@ export async function listMeetingsForMeetingAdmin(
 /**
  * Build update clauses for meeting updates
  */
+// eslint-disable-next-line complexity -- Necessary for dynamic update handling
 async function buildMeetingUpdateClauses(
 	updates: UpdateMeetingRequest,
 ): Promise<{ setClauses: string[]; values: Record<string, unknown> }> {
@@ -404,6 +435,7 @@ async function buildMeetingUpdateClauses(
 		startDate,
 		endDate,
 		quorumVotingPoolId,
+		quorumPercentage,
 		watcherPoolId,
 		meetingAdminPoolId,
 	} = updates;
@@ -435,6 +467,11 @@ async function buildMeetingUpdateClauses(
 		await verifyPoolExists(quorumVotingPoolId, "Pool");
 		setClauses.push(`quorum_voting_pool_id = :quorumVotingPoolId`);
 		values.quorumVotingPoolId = quorumVotingPoolId;
+	}
+
+	if (quorumPercentage !== undefined) {
+		setClauses.push(`quorum_percentage = :quorumPercentage`);
+		values.quorumPercentage = quorumPercentage;
 	}
 
 	if (watcherPoolId !== undefined) {
@@ -483,6 +520,8 @@ export async function updateMeeting(
 		start_date: Date;
 		end_date: Date;
 		quorum_voting_pool_id: number;
+		quorum_percentage: string;
+		quorum_eligible_snapshot: number | null;
 		watcher_pool_id: number | null;
 		meeting_admin_pool_id: number | null;
 		quorum_called_at: Date | null;
@@ -513,6 +552,8 @@ export async function updateMeeting(
 		startDate: row.start_date,
 		endDate: row.end_date,
 		quorumVotingPoolId: row.quorum_voting_pool_id,
+		quorumPercentage: parseFloat(row.quorum_percentage),
+		quorumEligibleSnapshot: row.quorum_eligible_snapshot,
 		watcherPoolId: row.watcher_pool_id,
 		meetingAdminPoolId: row.meeting_admin_pool_id,
 		quorumCalledAt: row.quorum_called_at,

--- a/packages/server/src/services/motion-service.ts
+++ b/packages/server/src/services/motion-service.ts
@@ -27,13 +27,15 @@ interface OpenMotionRow {
 }
 
 /**
- * Get open motions for a specific user based on their pool memberships
+ * Get open motions for a specific user based on their current meeting participation
  *
  * Business Logic:
  * 1. Motion status must be 'voting_active'
- * 2. User must belong to the motion's voting pool (via user_pools)
- * 3. If motion has no voting_pool_id, fall back to meeting's quorum_voting_pool_id
- * 4. User must not have already voted on the motion
+ * 2. User must have joined the meeting as a voter (via meeting_participants)
+ * 3. User must still be active in the meeting (left_at IS NULL)
+ * 4. User must belong to the motion's voting pool (via user_pools)
+ * 5. If motion has no voting_pool_id, fall back to meeting's quorum_voting_pool_id
+ * 6. User must not have already voted on the motion
  *
  * Returns motions sorted by when voting started (oldest first)
  */
@@ -54,6 +56,10 @@ export async function getOpenMotionsForUser(
 			m.voting_started_at
 		 FROM motions m
 		 INNER JOIN meetings mt ON m.meeting_id = mt.id
+		 INNER JOIN meeting_participants mp ON mp.meeting_id = mt.id
+		   AND mp.user_id = :userId
+		   AND mp.role = 'voter'
+		   AND mp.left_at IS NULL
 		 LEFT JOIN pools p ON m.voting_pool_id = p.id
 		 LEFT JOIN pools qp ON mt.quorum_voting_pool_id = qp.id
 		 INNER JOIN user_pools up ON up.pool_id = COALESCE(m.voting_pool_id, mt.quorum_voting_pool_id)

--- a/packages/server/src/services/quorum-service.ts
+++ b/packages/server/src/services/quorum-service.ts
@@ -27,6 +27,8 @@ const ZERO_COUNT = 0;
  * - Counts voters who have explicitly joined the meeting and were counted for quorum
  * - quorum_counted_at is set when a voter joins before quorum is called
  * - Once quorum is called, new joiners are not counted toward quorum
+ * - Uses quorum_eligible_snapshot if set (quorum was called), otherwise live count
+ * - Calculates votersNeededForQuorum = Math.round(totalEligible * percentage / 100)
  */
 export async function getQuorumReport(
 	meetingId: number,
@@ -39,10 +41,13 @@ export async function getQuorumReport(
 		end_date: Date;
 		quorum_voting_pool_id: number;
 		quorum_called_at: Date | null;
+		quorum_percentage: string;
+		quorum_eligible_snapshot: number | null;
 		pool_name: string;
 	}>(
 		`SELECT m.id, m.name, m.start_date, m.end_date,
 		        m.quorum_voting_pool_id, m.quorum_called_at,
+		        m.quorum_percentage, m.quorum_eligible_snapshot,
 		        p.pool_name
 		 FROM meetings m
 		 INNER JOIN pools p ON m.quorum_voting_pool_id = p.id
@@ -58,17 +63,31 @@ export async function getQuorumReport(
 		rows: [meeting],
 	} = meetingResult;
 
-	// Get total eligible voters from quorum pool
-	const eligibleResult = await db.query<{ count: string }>(
-		`SELECT COUNT(DISTINCT user_id) as count
-		 FROM user_pools
-		 WHERE pool_id = :poolId`,
-		{ poolId: meeting.quorum_voting_pool_id },
-	);
-	const totalEligibleVoters = parseInt(
-		eligibleResult.rows[FIRST_ROW].count,
-		DECIMAL_RADIX,
-	);
+	// Parse quorum percentage (stored as DECIMAL in database)
+	const quorumPercentage = parseFloat(meeting.quorum_percentage);
+
+	// Determine total eligible voters:
+	// - Use snapshot if quorum was called (frozen value)
+	// - Otherwise use live count from quorum pool
+	const { quorum_eligible_snapshot: snapshot } = meeting;
+	const isSnapshotted = snapshot !== null;
+
+	const totalEligibleVoters = isSnapshotted
+		? snapshot
+		: await (async (): Promise<number> => {
+				// Count only actual voters (exclude admin/watcher/meeting_admin)
+				const eligibleResult = await db.query<{ count: string }>(
+					`SELECT COUNT(DISTINCT up.user_id) as count
+					 FROM user_pools up
+					 INNER JOIN users u ON up.user_id = u.id
+					 WHERE up.pool_id = :poolId
+					   AND u.is_admin = FALSE
+					   AND u.is_watcher = FALSE
+					   AND u.is_meeting_admin = FALSE`,
+					{ poolId: meeting.quorum_voting_pool_id },
+				);
+				return parseInt(eligibleResult.rows[FIRST_ROW].count, DECIMAL_RADIX);
+			})();
 
 	// Get count of voters who have been counted for quorum (quorum_counted_at IS NOT NULL)
 	const activeResult = await db.query<{ count: string }>(
@@ -84,11 +103,19 @@ export async function getQuorumReport(
 		DECIMAL_RADIX,
 	);
 
-	// Calculate percentage
+	// Calculate percentage of eligible voters present
 	const activeVoterPercentage =
 		totalEligibleVoters > ZERO_COUNT
 			? (activeVoterCount / totalEligibleVoters) * PERCENTAGE_MULTIPLIER
 			: ZERO_COUNT;
+
+	// Calculate voters needed for quorum (round to nearest integer)
+	const votersNeededForQuorum = Math.round(
+		(totalEligibleVoters * quorumPercentage) / PERCENTAGE_MULTIPLIER,
+	);
+
+	// Determine if quorum is achieved
+	const hasQuorum = activeVoterCount >= votersNeededForQuorum;
 
 	// Calculate as of time - use quorum_called_at if set, otherwise now
 	const calculatedAsOf = meeting.quorum_called_at ?? new Date();
@@ -104,11 +131,22 @@ export async function getQuorumReport(
 		meetingStartDate: meeting.start_date,
 		meetingEndDate: meeting.end_date,
 		quorumPoolName: meeting.pool_name,
+		quorumPercentage,
+		votersNeededForQuorum,
+		hasQuorum,
+		isSnapshotted,
 	};
 }
 
 /**
  * Call quorum for a meeting (set the quorum_called_at timestamp)
+ *
+ * When calling quorum (setting timestamp):
+ * - Snapshots the current eligible voter count from the quorum pool
+ * - This ensures quorum reports don't change if pool membership changes later
+ *
+ * When uncalling quorum (setting to null):
+ * - Clears the snapshot so live count is used again
  *
  * @param meetingId - The meeting ID
  * @param quorumCalledAt - The timestamp when quorum was called, or null to clear
@@ -117,12 +155,66 @@ export async function callQuorum(
 	meetingId: number,
 	quorumCalledAt: Date | null,
 ): Promise<void> {
+	// Uncalling quorum - clear both timestamp and snapshot
+	if (quorumCalledAt === null) {
+		const result = await db.query(
+			`UPDATE meetings
+			 SET quorum_called_at = NULL,
+			     quorum_eligible_snapshot = NULL,
+			     updated_at = NOW()
+			 WHERE id = :meetingId
+			 RETURNING id`,
+			{ meetingId },
+		);
+
+		if (result.rows.length === EMPTY_ARRAY_LENGTH) {
+			throw new Error(`Meeting with ID ${String(meetingId)} not found`);
+		}
+		return;
+	}
+
+	// Calling quorum - snapshot the eligible voter count
+	// First, get the quorum pool ID for this meeting
+	const meetingResult = await db.query<{
+		quorum_voting_pool_id: number;
+	}>(`SELECT quorum_voting_pool_id FROM meetings WHERE id = :meetingId`, {
+		meetingId,
+	});
+
+	if (meetingResult.rows.length === EMPTY_ARRAY_LENGTH) {
+		throw new Error(`Meeting with ID ${String(meetingId)} not found`);
+	}
+
+	const {
+		rows: [{ quorum_voting_pool_id: poolId }],
+	} = meetingResult;
+
+	// Get current eligible voter count from the pool
+	// Count only actual voters (exclude admin/watcher/meeting_admin)
+	const eligibleResult = await db.query<{ count: string }>(
+		`SELECT COUNT(DISTINCT up.user_id) as count
+		 FROM user_pools up
+		 INNER JOIN users u ON up.user_id = u.id
+		 WHERE up.pool_id = :poolId
+		   AND u.is_admin = FALSE
+		   AND u.is_watcher = FALSE
+		   AND u.is_meeting_admin = FALSE`,
+		{ poolId },
+	);
+	const eligibleSnapshot = parseInt(
+		eligibleResult.rows[FIRST_ROW].count,
+		DECIMAL_RADIX,
+	);
+
+	// Update meeting with both timestamp and snapshot
 	const result = await db.query(
 		`UPDATE meetings
-		 SET quorum_called_at = :quorumCalledAt, updated_at = NOW()
+		 SET quorum_called_at = :quorumCalledAt,
+		     quorum_eligible_snapshot = :eligibleSnapshot,
+		     updated_at = NOW()
 		 WHERE id = :meetingId
 		 RETURNING id`,
-		{ meetingId, quorumCalledAt },
+		{ meetingId, quorumCalledAt, eligibleSnapshot },
 	);
 
 	if (result.rows.length === EMPTY_ARRAY_LENGTH) {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -487,6 +487,8 @@ export interface Meeting {
 	startDate: Date;
 	endDate: Date;
 	quorumVotingPoolId: number;
+	quorumPercentage: number; // 0-100, percentage required for quorum
+	quorumEligibleSnapshot: number | null; // Snapshot of eligible count when quorum was called
 	watcherPoolId: number | null;
 	meetingAdminPoolId: number | null;
 	quorumCalledAt: Date | null;
@@ -685,6 +687,7 @@ export interface CreateMeetingRequest {
 	startDate: string; // ISO 8601 string
 	endDate: string; // ISO 8601 string
 	quorumVotingPoolId: number;
+	quorumPercentage?: number; // 0-100, defaults to 50 if not provided
 	voterPoolIds?: number[]; // Additional voter pools (quorum pool always included)
 	watcherPoolId?: number | null; // Auto-created if not provided
 	meetingAdminPoolId?: number | null; // Auto-created if not provided
@@ -699,6 +702,7 @@ export interface UpdateMeetingRequest {
 	startDate?: string; // ISO 8601 string
 	endDate?: string; // ISO 8601 string
 	quorumVotingPoolId?: number;
+	quorumPercentage?: number; // 0-100, percentage required for quorum
 	voterPoolIds?: number[]; // Replace all voter pools
 	watcherPoolId?: number | null;
 	meetingAdminPoolId?: number | null;
@@ -1041,6 +1045,10 @@ export interface QuorumReport {
 	totalEligibleVoters: number;
 	activeVoterCount: number;
 	activeVoterPercentage: number;
+	quorumPercentage: number; // Required percentage for quorum (0-100)
+	votersNeededForQuorum: number; // Calculated: round(totalEligible * percentage / 100)
+	hasQuorum: boolean; // Whether quorum is achieved
+	isSnapshotted: boolean; // True if using frozen snapshot (quorum was called)
 	quorumCalledAt: Date | null;
 	calculatedAsOf: Date;
 	meetingStartDate: Date;


### PR DESCRIPTION
## Summary

- Adds `quorum_percentage` column to meetings table (default 50%) so each meeting can have its own quorum threshold
- Adds `quorum_eligible_snapshot` to freeze the eligible voter count when quorum is called, ensuring consistent numbers even if pool membership changes
- Calculates `votersNeededForQuorum` using `Math.round()` for nearest integer rounding
- Server-side `hasQuorum` calculation replaces hardcoded 50% comparisons in frontend
- Adds quorum percentage input field to meeting create/edit forms (placed after quorum pool selection)
- Adds "Quorum Achieved" / "Quorum Not Met" indicator to quorum reports for admins and watchers
- Displays quorum requirement (percentage and voters needed) in all quorum views
- Filters quorum eligible count to exclude admin/watcher/meeting_admin users (only voters count)
- Fixes bug where voters could see motions from meetings they haven't joined
- Hides pool information from voters in meeting selection view (security/UX improvement)

## Test plan

- [x] Create a new meeting with custom quorum percentage (e.g., 75%)
- [x] Verify percentage is saved and displayed correctly
- [x] Edit existing meeting's quorum percentage
- [x] Verify quorum calculation uses configured percentage
- [x] Verify "Quorum Achieved" indicator shows when threshold is met
- [x] Verify "Quorum Not Met" indicator shows correct voters needed count
- [x] Call quorum and verify eligible count is snapshotted
- [x] Uncall quorum and verify snapshot is cleared
- [x] Verify voters only see motions from their joined meeting
- [x] Verify pool info is hidden from voter meeting selection
- [x] All local tests run and passed

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)