### PR TITLE
Fix kiosk mode login restrictions and auto-fill prevention (Issue #130)

### DIFF
--- a/packages/client/src/composables/useActivityTimeout.ts
+++ b/packages/client/src/composables/useActivityTimeout.ts
@@ -27,7 +27,7 @@ interface ActivityTimeoutState {
 	showWarning: typeof showWarning;
 	warningSecondsLeft: typeof warningSecondsLeft;
 	confirmActivity: () => void;
-	startTracking: () => void;
+	startTracking: (logoutCallback: () => void) => void;
 	stopTracking: () => void;
 }
 

--- a/packages/client/src/composables/useKioskMode.ts
+++ b/packages/client/src/composables/useKioskMode.ts
@@ -19,21 +19,33 @@ const isInitialized = ref(false);
 /**
  * Initialize kiosk mode from URL query parameter
  * Should be called on app startup
+ *
+ * Kiosk mode can be controlled via URL:
+ * - ?KioskMode=true  → enables kiosk mode
+ * - ?KioskMode=false → disables kiosk mode and clears storage
+ * - No param         → preserves current state from sessionStorage
  */
 export function initKioskMode(searchParams: URLSearchParams): void {
 	const kioskParam = searchParams.get(KIOSK_QUERY_PARAM);
 
 	if (kioskParam === null) {
-		// Check sessionStorage for persisted value
+		// No param: check sessionStorage for persisted value
 		const storedValue = sessionStorage.getItem(KIOSK_STORAGE_KEY);
 		if (storedValue !== null) {
 			kioskModeEnabled.value = storedValue === "true";
 		}
 	} else {
+		// Param present: set based on value (supports both true and false)
 		const enabled = kioskParam.toLowerCase() === "true";
 		kioskModeEnabled.value = enabled;
-		// Store in sessionStorage to persist across page navigations
-		sessionStorage.setItem(KIOSK_STORAGE_KEY, String(enabled));
+
+		if (enabled) {
+			// Store in sessionStorage to persist across page navigations
+			sessionStorage.setItem(KIOSK_STORAGE_KEY, String(enabled));
+		} else {
+			// Explicitly disabled: clear sessionStorage
+			sessionStorage.removeItem(KIOSK_STORAGE_KEY);
+		}
 	}
 
 	isInitialized.value = true;

--- a/packages/client/src/views/AdminLayout.vue
+++ b/packages/client/src/views/AdminLayout.vue
@@ -1,18 +1,30 @@
 <script setup lang="ts">
-import { computed, onMounted } from "vue";
+import { computed, onMounted, onUnmounted, watch } from "vue";
 import { RouterLink, useRouter } from "vue-router";
 import { useAuth } from "../composables/useAuth";
 import { useAdminMeeting } from "../composables/useAdminMeeting";
 import { useMobileNav } from "../composables/useMobileNav";
+import { useKioskMode } from "../composables/useKioskMode";
+import { useActivityTimeout } from "../composables/useActivityTimeout";
 import NavDropdown from "../components/NavDropdown.vue";
 import NavHamburger from "../components/NavHamburger.vue";
 import MobileNavOverlay from "../components/MobileNavOverlay.vue";
+import KioskModeIndicator from "../components/KioskModeIndicator.vue";
+import InactivityWarningModal from "../components/InactivityWarningModal.vue";
 
 const router = useRouter();
 const { currentUser, isAdmin, isMeetingAdmin, logout } = useAuth();
+const { isKioskMode, getKioskModeQueryParam } = useKioskMode();
 const { isJoined, currentMeeting, loadCurrentMeeting, leaveMeeting } =
 	useAdminMeeting();
 const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
+const {
+	showWarning,
+	warningSecondsLeft,
+	confirmActivity,
+	startTracking,
+	stopTracking,
+} = useActivityTimeout();
 
 // Determine the admin role label for the header
 const adminRoleLabel = computed(() => {
@@ -47,9 +59,39 @@ async function handleLeaveMeetingMobile(): Promise<void> {
 	void router.push("/admin/meetings/select");
 }
 
-// Load current meeting state on mount
+/**
+ * Handle inactivity logout - called when countdown expires
+ */
+function handleInactivityLogout(): void {
+	logout();
+	// Redirect to login with kiosk param preserved
+	const kioskQuery = getKioskModeQueryParam();
+	void router.push({ path: "/login", query: kioskQuery });
+}
+
+/**
+ * Start or stop activity tracking based on kiosk mode
+ * All users (including admins) are subject to inactivity timeout in kiosk mode
+ */
+function updateActivityTracking(): void {
+	if (isKioskMode.value) {
+		startTracking(handleInactivityLogout);
+	} else {
+		stopTracking();
+	}
+}
+
+// Watch for changes in kiosk mode
+watch(isKioskMode, updateActivityTracking);
+
+// Load current meeting state on mount and start activity tracking
 onMounted(() => {
 	void loadCurrentMeeting();
+	updateActivityTracking();
+});
+
+onUnmounted(() => {
+	stopTracking();
 });
 </script>
 
@@ -291,6 +333,16 @@ onMounted(() => {
 		<main class="admin-content">
 			<router-view />
 		</main>
+
+		<!-- Kiosk mode indicator for global admins -->
+		<KioskModeIndicator v-if="isKioskMode" />
+
+		<!-- Inactivity warning modal for kiosk mode -->
+		<InactivityWarningModal
+			v-if="showWarning"
+			:seconds-left="warningSecondsLeft"
+			@confirm="confirmActivity"
+		/>
 	</div>
 </template>
 

--- a/packages/client/src/views/LoginPage.vue
+++ b/packages/client/src/views/LoginPage.vue
@@ -1,18 +1,70 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, computed, onMounted, nextTick } from "vue";
 import { useRouter } from "vue-router";
 import { useAuth } from "../composables/useAuth";
 import { useKioskMode } from "../composables/useKioskMode";
 import KioskModeIndicator from "../components/KioskModeIndicator.vue";
 
 const router = useRouter();
-const { login, isLoading } = useAuth();
+const { login, logout, currentUser, isLoading } = useAuth();
 const { isKioskMode } = useKioskMode();
 
 const username = ref("");
 const password = ref("");
 const showPassword = ref(false);
 const error = ref<string | null>(null);
+
+// Delay in ms before clearing auto-filled fields (allows browser to auto-fill first)
+const AUTO_FILL_CLEAR_DELAY_MS = 100;
+
+// Delay in ms before resetting the form after a kiosk login rejection
+const KIOSK_ERROR_RESET_DELAY_MS = 10000;
+
+// Computed properties for autocomplete - disabled in kiosk mode to prevent auto-fill
+const usernameAutocomplete = computed(() =>
+	isKioskMode.value ? "off" : "username",
+);
+const passwordAutocomplete = computed(() =>
+	isKioskMode.value ? "off" : "current-password",
+);
+
+// Disable "Show password" checkbox in kiosk mode until user types something
+// This prevents the browser from auto-filling credentials when the checkbox is clicked
+const showPasswordDisabled = computed(
+	() => isKioskMode.value && password.value === "",
+);
+
+/**
+ * Clear any auto-filled credentials in kiosk mode
+ * Browsers often ignore autocomplete="off", so we clear fields after mount
+ */
+function clearAutoFilledFields(): void {
+	if (isKioskMode.value) {
+		username.value = "";
+		password.value = "";
+	}
+}
+
+/**
+ * Reset the login form for kiosk mode
+ * Clears username, password, error message, and show password state
+ */
+function resetFormForKiosk(): void {
+	username.value = "";
+	password.value = "";
+	error.value = null;
+	showPassword.value = false;
+}
+
+// In kiosk mode, clear any auto-filled fields after component mounts
+// Use delay to allow browser auto-fill to complete first, then clear it
+onMounted(() => {
+	if (isKioskMode.value) {
+		void nextTick(() => {
+			setTimeout(clearAutoFilledFields, AUTO_FILL_CLEAR_DELAY_MS);
+		});
+	}
+});
 
 async function handleSubmit(): Promise<void> {
 	error.value = null;
@@ -24,6 +76,27 @@ async function handleSubmit(): Promise<void> {
 
 	try {
 		await login(username.value, password.value);
+
+		// In kiosk mode, restrict login to voters and global admins only
+		// Block watchers and meeting admins (they should use regular login)
+		if (isKioskMode.value) {
+			const user = currentUser.value;
+			if (
+				user !== null &&
+				!user.isAdmin &&
+				(user.isWatcher || user.isMeetingAdmin)
+			) {
+				// Clear auth and show error
+				logout();
+				password.value = "";
+				error.value =
+					"Kiosk mode is for voters only. Please use a different login method.";
+				// Auto-reset form after delay so kiosk is ready for next user
+				setTimeout(resetFormForKiosk, KIOSK_ERROR_RESET_DELAY_MS);
+				return;
+			}
+		}
+
 		void router.push("/");
 	} catch (err) {
 		error.value = err instanceof Error ? err.message : "Login failed";
@@ -50,7 +123,7 @@ async function handleSubmit(): Promise<void> {
 						type="text"
 						placeholder="Enter your username"
 						:disabled="isLoading"
-						autocomplete="username"
+						:autocomplete="usernameAutocomplete"
 					/>
 				</div>
 
@@ -62,7 +135,7 @@ async function handleSubmit(): Promise<void> {
 						:type="showPassword ? 'text' : 'password'"
 						placeholder="Enter your password"
 						:disabled="isLoading"
-						autocomplete="current-password"
+						:autocomplete="passwordAutocomplete"
 					/>
 				</div>
 
@@ -71,7 +144,7 @@ async function handleSubmit(): Promise<void> {
 						<input
 							v-model="showPassword"
 							type="checkbox"
-							:disabled="isLoading"
+							:disabled="isLoading || showPasswordDisabled"
 						/>
 						Show password
 					</label>

--- a/packages/client/src/views/VoterLayout.vue
+++ b/packages/client/src/views/VoterLayout.vue
@@ -13,7 +13,7 @@ import MobileNavOverlay from "../components/MobileNavOverlay.vue";
 
 const router = useRouter();
 const route = useRoute();
-const { currentUser, isAdmin, logout } = useAuth();
+const { currentUser, logout } = useAuth();
 const { isKioskMode, getKioskModeQueryParam } = useKioskMode();
 const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
 const {
@@ -37,19 +37,19 @@ function handleInactivityLogout(): void {
 }
 
 /**
- * Start or stop activity tracking based on kiosk mode and admin status
+ * Start or stop activity tracking based on kiosk mode
+ * All users (including admins) are subject to inactivity timeout in kiosk mode
  */
 function updateActivityTracking(): void {
-	// Only track activity for non-admin users in kiosk mode
-	if (isKioskMode.value && !isAdmin.value) {
+	if (isKioskMode.value) {
 		startTracking(handleInactivityLogout);
 	} else {
 		stopTracking();
 	}
 }
 
-// Watch for changes in kiosk mode or admin status
-watch([isKioskMode, isAdmin], updateActivityTracking);
+// Watch for changes in kiosk mode
+watch(isKioskMode, updateActivityTracking);
 
 // Re-check meeting participation on every navigation so a user who is kicked
 // mid-session is redirected to meeting selection on the next route change.


### PR DESCRIPTION
## Summary

- Add login restrictions in kiosk mode: block watchers and meeting admins, allow only voters and global admins
- Prevent browser auto-fill in kiosk mode with `autocomplete="off"` and field clearing
- Add activity timeout to AdminLayout (all users now subject to 60-second inactivity timeout in kiosk mode)
- Add `?KioskMode=false` URL parameter support to explicitly disable kiosk mode

## Changes

### Login Restrictions (LoginPage.vue)
- After successful login, check if user is watcher or meeting admin in kiosk mode
- Block with error message: "Kiosk mode is for voters only. Please use a different login method."
- Auto-reset form after 10 seconds so kiosk is ready for next user

### Auto-fill Prevention (LoginPage.vue)
- Set `autocomplete="off"` on username/password fields in kiosk mode
- Clear auto-filled fields 100ms after mount (browsers often ignore autocomplete)
- Disable "Show password" checkbox until user types in password field (prevents auto-fill trigger)

### Activity Timeout (AdminLayout.vue, VoterLayout.vue)
- Added activity timeout functionality to AdminLayout for global admins
- Removed admin exemption from VoterLayout - all users subject to timeout in kiosk mode
- 60 seconds inactivity → 10 second warning countdown → auto-logout

### Kiosk Mode Control (useKioskMode.ts)
- Added `?KioskMode=false` support to explicitly disable and clear sessionStorage
- No param preserves current state from sessionStorage

### Other
- Added KioskModeIndicator to AdminLayout for global admins
- Fixed TypeScript interface for `startTracking` parameter in useActivityTimeout

## Test plan

- [x] Navigate to `http://localhost:5173/login?KioskMode=true` - kiosk indicator appears
- [x] Log in as voter → succeeds, redirects to voter dashboard
- [x] Log in as global admin → succeeds, redirects to admin area with kiosk indicator
- [x] Log in as watcher → blocked with error message, form resets after 10 seconds
- [x] Log in as meeting admin → blocked with error message, form resets after 10 seconds
- [x] Auto-fill prevention working - fields do not auto-fill in kiosk mode
- [x] Show password checkbox disabled until password entered
- [x] Activity timeout works for voters (60s → warning → logout)
- [x] Activity timeout works for global admins (60s → warning → logout)
- [x] Navigate to `http://localhost:5173/login?KioskMode=false` - kiosk mode disabled
- [x] Kiosk query param preserved through all redirects

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)