### PR TITLE
Add projector meeting focus restrictions and display controls (Issue #131)

### DIFF
--- a/packages/client/src/composables/useProjector.ts
+++ b/packages/client/src/composables/useProjector.ts
@@ -62,6 +62,8 @@ export function useProjectorControl(): {
 	isDisplayConnected: Ref<boolean>;
 	currentState: Ref<ProjectorState>;
 	openDisplayWindow: () => void;
+	focusDisplayWindow: () => void;
+	closeDisplayWindow: () => void;
 	sendState: (state: ProjectorState) => void;
 	updateMode: (mode: ProjectorDisplayMode) => void;
 	updateMeetingId: (meetingId: number | null) => void;
@@ -75,6 +77,7 @@ export function useProjectorControl(): {
 	const currentState = ref<ProjectorState>(createDefaultState());
 	let channel: BroadcastChannelType | null = null;
 	let pingInterval: ReturnType<typeof setInterval> | null = null;
+	let displayWindow: ReturnType<typeof window.open> = null;
 
 	// Initialize BroadcastChannel
 	function initChannel(): void {
@@ -117,6 +120,8 @@ export function useProjectorControl(): {
 
 	function sendPing(): void {
 		if (channel === null) return;
+		// Set to false before ping - will be set to true if display responds
+		isDisplayConnected.value = false;
 		const message: ProjectorMessage = {
 			type: "ping",
 			timestamp: Date.now(),
@@ -128,7 +133,7 @@ export function useProjectorControl(): {
 	 * Open the projector display window
 	 */
 	function openDisplayWindow(): void {
-		window.open(
+		displayWindow = window.open(
 			PROJECTOR_DISPLAY_PATH,
 			"projector-display",
 			"width=1920,height=1080",
@@ -143,6 +148,29 @@ export function useProjectorControl(): {
 		setTimeout(() => {
 			sendState(currentState.value);
 		}, DISPLAY_INIT_DELAY_MS);
+	}
+
+	/**
+	 * Focus the existing projector display window (bring to front)
+	 */
+	function focusDisplayWindow(): void {
+		if (displayWindow !== null && !displayWindow.closed) {
+			displayWindow.focus();
+		} else {
+			// Window was closed or never opened, open a new one
+			openDisplayWindow();
+		}
+	}
+
+	/**
+	 * Close the projector display window
+	 */
+	function closeDisplayWindow(): void {
+		if (displayWindow !== null && !displayWindow.closed) {
+			displayWindow.close();
+			displayWindow = null;
+			isDisplayConnected.value = false;
+		}
 	}
 
 	/**
@@ -257,6 +285,8 @@ export function useProjectorControl(): {
 		isDisplayConnected,
 		currentState,
 		openDisplayWindow,
+		focusDisplayWindow,
+		closeDisplayWindow,
 		sendState,
 		updateMode,
 		updateMeetingId,

--- a/packages/client/src/views/admin/ProjectorControl.vue
+++ b/packages/client/src/views/admin/ProjectorControl.vue
@@ -13,6 +13,7 @@ import {
 	type QuorumReport,
 } from "@mcdc-convention-voting/shared";
 import QrcodeVue from "qrcode.vue";
+import { useAdminMeeting } from "../../composables/useAdminMeeting";
 import { useCountdownTimer } from "../../composables/useCountdownTimer";
 import { useProjectorControl } from "../../composables/useProjector";
 import {
@@ -39,8 +40,21 @@ const MS_PER_SECOND = 1000;
 const SECONDS_PER_MINUTE = 60;
 
 // Projector control composable
-const { isDisplayConnected, currentState, openDisplayWindow, sendState } =
-	useProjectorControl();
+const {
+	isDisplayConnected,
+	currentState,
+	openDisplayWindow,
+	focusDisplayWindow,
+	closeDisplayWindow,
+	sendState,
+} = useProjectorControl();
+
+// Admin meeting focus composable
+const {
+	isJoined,
+	joinedMeetingId,
+	currentMeeting: adminCurrentMeeting,
+} = useAdminMeeting();
 
 // Data
 const meetings = ref<MeetingWithPool[]>([]);
@@ -144,6 +158,20 @@ const selectedMeeting = computed(() => {
 	if (previewState.value.meetingId === null) return null;
 	return meetings.value.find((m) => m.id === previewState.value.meetingId);
 });
+
+// Whether meeting selection is locked to focused meeting
+const isMeetingLocked = computed(() => isJoined.value);
+
+// Check if focused meeting is available in the meetings list
+const focusedMeetingAvailable = computed(() => {
+	if (!isJoined.value || joinedMeetingId.value === null) return true;
+	return meetings.value.some((m) => m.id === joinedMeetingId.value);
+});
+
+// Whether projector controls should be disabled (focused but meeting not available)
+const isProjectorDisabled = computed(
+	() => isJoined.value && !focusedMeetingAvailable.value,
+);
 
 const requiresMeeting = computed(() => {
 	const mode = previewState.value.mode;
@@ -489,6 +517,23 @@ watch(
 	},
 );
 
+// Watch for admin meeting focus changes to auto-select meeting
+watch(
+	[isJoined, joinedMeetingId],
+	([joined, meetingId]) => {
+		if (joined && meetingId !== null) {
+			// Auto-select focused meeting
+			previewState.value = {
+				...previewState.value,
+				meetingId,
+				motionId: null,
+			};
+			void loadMotions(meetingId);
+		}
+	},
+	{ immediate: true },
+);
+
 // Initialize
 onMounted(() => {
 	void loadMeetings();
@@ -513,9 +558,29 @@ onUnmounted(() => {
 				<span v-else class="connection-status disconnected">
 					Display Not Connected
 				</span>
-				<button class="btn btn-primary" @click="handleOpenDisplay">
-					Open Display Window
-				</button>
+				<div class="display-buttons">
+					<button
+						v-if="isDisplayConnected"
+						class="btn btn-primary"
+						@click="focusDisplayWindow"
+					>
+						Focus Display
+					</button>
+					<button
+						v-if="isDisplayConnected"
+						class="btn btn-secondary"
+						@click="closeDisplayWindow"
+					>
+						Close Display
+					</button>
+					<button
+						v-if="!isDisplayConnected"
+						class="btn btn-primary"
+						@click="handleOpenDisplay"
+					>
+						Open Display Window
+					</button>
+				</div>
 			</div>
 		</div>
 
@@ -523,22 +588,39 @@ onUnmounted(() => {
 			<!-- Meeting Selection -->
 			<div class="section">
 				<h3>Meeting</h3>
+				<div
+					v-if="isMeetingLocked && !focusedMeetingAvailable"
+					class="alert alert-warning"
+				>
+					The focused meeting is not available. Please leave the meeting focus
+					or select a different meeting.
+				</div>
 				<select
 					:value="previewState.meetingId ?? ''"
-					:disabled="loadingMeetings"
+					:disabled="loadingMeetings || isMeetingLocked || isProjectorDisabled"
 					@change="handleMeetingChange"
 				>
-					<option value="">
+					<option
+						v-if="isMeetingLocked && focusedMeetingAvailable"
+						:value="joinedMeetingId"
+					>
+						{{ adminCurrentMeeting?.meeting.name }} (Focused)
+					</option>
+					<option v-else-if="!isMeetingLocked" value="">
 						{{ loadingMeetings ? "Loading..." : "Select a meeting..." }}
 					</option>
 					<option
 						v-for="meeting in meetings"
 						:key="meeting.id"
 						:value="meeting.id"
+						:hidden="isMeetingLocked"
 					>
 						{{ meeting.name }}
 					</option>
 				</select>
+				<p v-if="isMeetingLocked" class="locked-note">
+					Meeting selection is locked to your focused meeting.
+				</p>
 			</div>
 
 			<!-- Motion Selection (when required) -->
@@ -1007,15 +1089,17 @@ onUnmounted(() => {
 			<div class="section actions-section">
 				<button
 					class="btn btn-success btn-large"
-					:disabled="!canProject || !isPreviewDifferent"
+					:disabled="!canProject || !isPreviewDifferent || isProjectorDisabled"
 					@click="projectNow"
 				>
 					{{
-						!isPreviewDifferent
-							? "Already Projected"
-							: canProject
-								? "Project Now"
-								: "Complete Settings to Project"
+						isProjectorDisabled
+							? "Focused Meeting Not Available"
+							: !isPreviewDifferent
+								? "Already Projected"
+								: canProject
+									? "Project Now"
+									: "Complete Settings to Project"
 					}}
 				</button>
 			</div>
@@ -1046,6 +1130,11 @@ onUnmounted(() => {
 	display: flex;
 	align-items: center;
 	gap: 1rem;
+}
+
+.display-buttons {
+	display: flex;
+	gap: 0.5rem;
 }
 
 .connection-status {
@@ -1085,6 +1174,26 @@ onUnmounted(() => {
 	font-size: 1rem;
 	font-weight: 600;
 	color: #2c3e50;
+}
+
+.alert {
+	padding: 0.75rem 1rem;
+	border-radius: 4px;
+	margin-bottom: 0.75rem;
+	font-size: 0.875rem;
+}
+
+.alert-warning {
+	background-color: #fff3cd;
+	color: #856404;
+	border: 1px solid #ffc107;
+}
+
+.locked-note {
+	margin: 0.5rem 0 0 0;
+	font-size: 0.875rem;
+	color: #666;
+	font-style: italic;
 }
 
 select,
@@ -1660,6 +1769,15 @@ textarea:disabled {
 
 .btn-primary:hover:not(:disabled) {
 	background-color: #1565c0;
+}
+
+.btn-secondary {
+	background-color: #6c757d;
+	color: white;
+}
+
+.btn-secondary:hover:not(:disabled) {
+	background-color: #5a6268;
 }
 
 .btn-success {


### PR DESCRIPTION
## Summary

- **Meeting Focus Integration**: When an admin joins/focuses on a meeting, the Projector Control now auto-selects that meeting and locks the dropdown to prevent changing it
- **Display Window Management**: Fixed connection status not updating when display window is closed, and added Focus/Close display buttons for better control

## Changes

### ProjectorControl.vue
- Import and use `useAdminMeeting` composable for focus state
- Add computed properties: `isMeetingLocked`, `focusedMeetingAvailable`, `isProjectorDisabled`
- Auto-select focused meeting with watcher on `isJoined`/`joinedMeetingId`
- Lock meeting dropdown when in focus mode with "(Focused)" label
- Show warning if focused meeting is not available
- Update display buttons: Focus Display / Close Display when connected

### useProjector.ts
- Fix connection status by setting `isDisplayConnected` to false before each ping
- Store window reference for focus/close operations
- Add `focusDisplayWindow()` to bring existing window to front
- Add `closeDisplayWindow()` to close window programmatically

## Test plan

- [x] Global admin without focus can select any meeting
- [x] Global admin with focus sees meeting auto-selected and locked
- [x] Meeting admin sees their meeting auto-selected and locked
- [x] Cannot change meeting when in focused mode
- [x] Clear visual indicator that meeting is locked/focused "(Focused)"
- [x] "Meeting selection is locked" note appears when locked
- [x] Display connection status updates within 5 seconds of closing window
- [x] "Focus Display" brings existing window to front
- [x] "Close Display" closes window and updates status immediately
- [x] All lint/type checks pass
- [x] All unit tests pass

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)