### PR TITLE
Add watcher meeting focus and UX improvements (Issue #134)

### DIFF
--- a/packages/client/src/views/WatcherLayout.vue
+++ b/packages/client/src/views/WatcherLayout.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
+import { ref, onMounted, watch } from "vue";
 import { RouterLink, useRouter, useRoute } from "vue-router";
 import { useAuth } from "../composables/useAuth";
 import { useKioskMode } from "../composables/useKioskMode";
 import { useMobileNav } from "../composables/useMobileNav";
-import { getCurrentMeetingForWatcher } from "../services/api";
+import {
+	getCurrentMeetingForWatcher,
+	leaveMeetingAsWatcher,
+} from "../services/api";
 import NavHamburger from "../components/NavHamburger.vue";
 import MobileNavOverlay from "../components/MobileNavOverlay.vue";
+import type { CurrentMeetingInfo } from "@mcdc-convention-voting/shared";
 
 const router = useRouter();
 const route = useRoute();
@@ -15,6 +19,46 @@ const { getKioskModeQueryParam } = useKioskMode();
 const { isOpen: isMobileNavOpen, toggleNav, closeNav } = useMobileNav();
 
 const meetingCheckComplete = ref(false);
+const currentMeetingInfo = ref<CurrentMeetingInfo | null>(null);
+const isLeavingMeeting = ref(false);
+
+// Re-check meeting participation on route changes
+// This ensures the meeting indicator updates after joining a meeting
+watch(
+	() => route.path,
+	(newPath, oldPath) => {
+		if (newPath === oldPath) {
+			return;
+		}
+		void checkMeetingParticipation();
+	},
+);
+
+/**
+ * Leave current meeting and return to meeting selection
+ */
+async function handleLeaveMeeting(): Promise<void> {
+	isLeavingMeeting.value = true;
+	try {
+		await leaveMeetingAsWatcher();
+		currentMeetingInfo.value = null;
+		closeNav();
+		const kioskQuery = getKioskModeQueryParam();
+		await router.push({
+			path: "/watcher/meeting-selection",
+			query: kioskQuery,
+		});
+	} catch {
+		// Still redirect on error - meeting may already be left
+		const kioskQuery = getKioskModeQueryParam();
+		await router.push({
+			path: "/watcher/meeting-selection",
+			query: kioskQuery,
+		});
+	} finally {
+		isLeavingMeeting.value = false;
+	}
+}
 
 /**
  * Check if watcher has an active meeting participation
@@ -34,6 +78,7 @@ async function checkMeetingParticipation(): Promise<void> {
 			if (currentMeeting === null) {
 				// Watcher has no active meeting, redirect to meeting selection
 				// Must await to prevent race condition with child component redirects
+				currentMeetingInfo.value = null;
 				const kioskQuery = getKioskModeQueryParam();
 				await router.push({
 					path: "/watcher/meeting-selection",
@@ -43,10 +88,13 @@ async function checkMeetingParticipation(): Promise<void> {
 				meetingCheckComplete.value = true;
 				return;
 			}
+			// Store the current meeting info for display
+			currentMeetingInfo.value = currentMeeting;
 		}
 		meetingCheckComplete.value = true;
 	} catch {
 		// On error, redirect to meeting selection
+		currentMeetingInfo.value = null;
 		const kioskQuery = getKioskModeQueryParam();
 		await router.push({
 			path: "/watcher/meeting-selection",
@@ -67,7 +115,7 @@ onMounted(() => {
 		<header class="watcher-header">
 			<div class="header-top">
 				<RouterLink to="/watcher" class="logo-link">
-					<h1>MCDC Convention Voting - Observer</h1>
+					<h1>MCDC Convention Voting - Watcher</h1>
 				</RouterLink>
 				<div class="user-info desktop-nav">
 					<span v-if="currentUser">{{ currentUser.username }}</span>
@@ -79,10 +127,22 @@ onMounted(() => {
 					@toggle="toggleNav"
 				/>
 			</div>
-			<nav class="watcher-nav desktop-nav">
+			<!-- Meeting indicator -->
+			<div v-if="currentMeetingInfo !== null" class="meeting-indicator">
+				<span class="meeting-label">Observing:</span>
+				<span class="meeting-name">{{ currentMeetingInfo.meeting.name }}</span>
+			</div>
+			<nav v-if="currentMeetingInfo !== null" class="watcher-nav desktop-nav">
 				<router-link to="/watcher/meetings" class="nav-link">
-					Meetings
+					Current Meeting
 				</router-link>
+				<button
+					class="nav-link change-meeting-btn"
+					:disabled="isLeavingMeeting"
+					@click="handleLeaveMeeting"
+				>
+					{{ isLeavingMeeting ? "Leaving..." : "Change Meeting" }}
+				</button>
 			</nav>
 		</header>
 
@@ -92,13 +152,28 @@ onMounted(() => {
 				<div v-if="currentUser" class="mobile-user-name">
 					{{ currentUser.username }}
 				</div>
+				<div v-if="currentMeetingInfo !== null" class="mobile-meeting-info">
+					<span class="mobile-meeting-label">Observing:</span>
+					<span class="mobile-meeting-name">{{
+						currentMeetingInfo.meeting.name
+					}}</span>
+				</div>
 				<RouterLink
+					v-if="currentMeetingInfo !== null"
 					to="/watcher/meetings"
 					class="mobile-nav-link"
 					@click="closeNav"
 				>
-					Meetings
+					Current Meeting
 				</RouterLink>
+				<button
+					v-if="currentMeetingInfo !== null"
+					class="mobile-nav-link change-meeting-mobile"
+					:disabled="isLeavingMeeting"
+					@click="handleLeaveMeeting"
+				>
+					{{ isLeavingMeeting ? "Leaving..." : "Change Meeting" }}
+				</button>
 				<button class="mobile-logout-btn" @click="logout">Logout</button>
 			</div>
 		</MobileNavOverlay>
@@ -127,7 +202,28 @@ onMounted(() => {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	margin-bottom: 1rem;
+	margin-bottom: 0.5rem;
+}
+
+.meeting-indicator {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.5rem 0.75rem;
+	background-color: rgba(255, 255, 255, 0.15);
+	border-radius: 4px;
+	margin-bottom: 0.75rem;
+	font-size: 0.9rem;
+}
+
+.meeting-label {
+	color: rgba(255, 255, 255, 0.8);
+	font-weight: 500;
+}
+
+.meeting-name {
+	color: white;
+	font-weight: 600;
 }
 
 .watcher-header h1 {
@@ -181,6 +277,24 @@ onMounted(() => {
 	background-color: rgba(255, 255, 255, 0.2);
 }
 
+.change-meeting-btn {
+	background: transparent;
+	border: 1px solid rgba(255, 255, 255, 0.5);
+	cursor: pointer;
+	font-size: inherit;
+	font-family: inherit;
+}
+
+.change-meeting-btn:hover:not(:disabled) {
+	background-color: rgba(255, 255, 255, 0.2);
+	border-color: rgba(255, 255, 255, 0.8);
+}
+
+.change-meeting-btn:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
 .watcher-content {
 	flex: 1;
 	padding: 2rem;
@@ -206,6 +320,40 @@ onMounted(() => {
 	color: white;
 	border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 	margin-bottom: 0.5rem;
+}
+
+.mobile-meeting-info {
+	padding: 0.75rem 1rem;
+	background-color: rgba(255, 255, 255, 0.1);
+	border-radius: 4px;
+	margin: 0 0.5rem 0.5rem 0.5rem;
+}
+
+.mobile-meeting-label {
+	display: block;
+	font-size: 0.75rem;
+	color: rgba(255, 255, 255, 0.7);
+	margin-bottom: 0.25rem;
+}
+
+.mobile-meeting-name {
+	display: block;
+	font-size: 0.9rem;
+	color: white;
+	font-weight: 600;
+}
+
+.change-meeting-mobile {
+	background: transparent;
+	border: none;
+	text-align: left;
+	cursor: pointer;
+	font-family: inherit;
+}
+
+.change-meeting-mobile:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
 }
 
 .mobile-nav-link {

--- a/packages/client/src/views/watcher/WatcherMeetingList.vue
+++ b/packages/client/src/views/watcher/WatcherMeetingList.vue
@@ -1,149 +1,190 @@
 <script setup lang="ts">
-import { ref, onMounted, computed } from "vue";
+import { ref, onMounted } from "vue";
 import { useRouter } from "vue-router";
-import { getWatcherMeetings } from "../../services/api";
-import TablePagination from "../../components/TablePagination.vue";
-import type { WatcherMeetingReport } from "@mcdc-convention-voting/shared";
+import {
+	getCurrentMeetingForWatcher,
+	getWatcherMeetingReport,
+	leaveMeetingAsWatcher,
+} from "../../services/api";
+import { useKioskMode } from "../../composables/useKioskMode";
+import type {
+	CurrentMeetingInfo,
+	WatcherMeetingReport,
+} from "@mcdc-convention-voting/shared";
 
 const router = useRouter();
+const { getKioskModeQueryParam } = useKioskMode();
 
-const MEETINGS_PER_PAGE = 50;
-const INITIAL_PAGE = 1;
-const INITIAL_TOTAL = 0;
-
-const meetings = ref<WatcherMeetingReport[]>([]);
+const currentMeetingInfo = ref<CurrentMeetingInfo | null>(null);
+const meetingReport = ref<WatcherMeetingReport | null>(null);
 const loading = ref(false);
 const error = ref<string | null>(null);
-const currentPage = ref(INITIAL_PAGE);
-const totalMeetings = ref(INITIAL_TOTAL);
+const isLeavingMeeting = ref(false);
 
-const totalPages = computed(() =>
-	Math.ceil(totalMeetings.value / MEETINGS_PER_PAGE),
-);
-
-async function loadMeetings(): Promise<void> {
+/**
+ * Load the current meeting the watcher has joined
+ */
+async function loadCurrentMeeting(): Promise<void> {
 	loading.value = true;
 	error.value = null;
 
 	try {
-		const response = await getWatcherMeetings(
-			currentPage.value,
-			MEETINGS_PER_PAGE,
+		// First get the current meeting info
+		const currentResponse = await getCurrentMeetingForWatcher();
+		if (
+			!currentResponse.success ||
+			currentResponse.data === undefined ||
+			currentResponse.data === null
+		) {
+			// No meeting joined - layout will handle redirect
+			currentMeetingInfo.value = null;
+			return;
+		}
+
+		currentMeetingInfo.value = currentResponse.data;
+
+		// Now load the detailed meeting report for this meeting
+		const reportResponse = await getWatcherMeetingReport(
+			currentResponse.data.meeting.id,
 		);
-		meetings.value = response.data;
-		totalMeetings.value = response.pagination.total;
+		if (reportResponse.success && reportResponse.data !== undefined) {
+			meetingReport.value = reportResponse.data;
+		}
 	} catch (err) {
-		error.value =
-			err instanceof Error ? err.message : "Failed to load meetings";
+		error.value = err instanceof Error ? err.message : "Failed to load meeting";
 	} finally {
 		loading.value = false;
 	}
 }
 
-function viewMeeting(meetingId: number): void {
-	void router.push(`/watcher/meetings/${meetingId}`);
+/**
+ * Leave current meeting and return to meeting selection
+ */
+async function handleChangeMeeting(): Promise<void> {
+	isLeavingMeeting.value = true;
+	try {
+		await leaveMeetingAsWatcher();
+		const kioskQuery = getKioskModeQueryParam();
+		await router.push({
+			path: "/watcher/meeting-selection",
+			query: kioskQuery,
+		});
+	} catch {
+		// Still redirect on error
+		const kioskQuery = getKioskModeQueryParam();
+		await router.push({
+			path: "/watcher/meeting-selection",
+			query: kioskQuery,
+		});
+	} finally {
+		isLeavingMeeting.value = false;
+	}
 }
 
-function viewQuorum(meetingId: number): void {
-	void router.push(`/watcher/meetings/${meetingId}/quorum`);
+function viewMeetingDetails(): void {
+	if (currentMeetingInfo.value === null) return;
+	void router.push(`/watcher/meetings/${currentMeetingInfo.value.meeting.id}`);
+}
+
+function viewQuorum(): void {
+	if (currentMeetingInfo.value === null) return;
+	void router.push(
+		`/watcher/meetings/${currentMeetingInfo.value.meeting.id}/quorum`,
+	);
 }
 
 function formatDate(date: Date | string): string {
 	return new Date(date).toLocaleString();
 }
 
-function goToPage(page: number): void {
-	currentPage.value = page;
-	void loadMeetings();
-}
-
 onMounted(() => {
-	void loadMeetings();
+	void loadCurrentMeeting();
 });
 </script>
 
 <template>
 	<div class="meeting-list">
 		<div class="header">
-			<h2>Meetings</h2>
+			<h2>Current Meeting</h2>
+			<button
+				class="btn btn-change"
+				:disabled="isLeavingMeeting"
+				@click="handleChangeMeeting"
+			>
+				{{ isLeavingMeeting ? "Leaving..." : "Change Meeting" }}
+			</button>
 		</div>
 
-		<div v-if="error" class="error">
+		<div v-if="error !== null" class="error">
 			{{ error }}
 		</div>
 
-		<div v-if="loading" class="loading">Loading meetings...</div>
+		<div v-if="loading" class="loading">Loading meeting...</div>
 
-		<div v-else-if="meetings.length === 0" class="empty">
-			No meetings found.
+		<div v-else-if="meetingReport === null" class="empty">
+			No meeting selected. Please select a meeting to observe.
 		</div>
 
-		<div v-else class="table-container">
-			<table class="meetings-table">
-				<thead>
-					<tr>
-						<th>Name</th>
-						<th>Description</th>
-						<th>Start Date</th>
-						<th>End Date</th>
-						<th>Quorum Pool</th>
-						<th>Quorum Status</th>
-						<th>Motions</th>
-						<th>Actions</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr v-for="meeting in meetings" :key="meeting.meetingId">
-						<td class="meeting-name">
-							{{ meeting.meetingName }}
-						</td>
-						<td class="description">
-							{{ meeting.description || "—" }}
-						</td>
-						<td>{{ formatDate(meeting.startDate) }}</td>
-						<td>{{ formatDate(meeting.endDate) }}</td>
-						<td>{{ meeting.quorumPoolName }}</td>
-						<td>
-							<span
-								v-if="meeting.quorumCalledAt !== null"
-								class="status-badge called"
-							>
-								Called
-							</span>
-							<span v-else class="status-badge not-called"> Not Called </span>
-						</td>
-						<td>{{ meeting.motionSummaries.length }}</td>
-						<td class="actions-cell">
-							<button
-								class="btn btn-small"
-								@click="viewMeeting(meeting.meetingId)"
-							>
-								View Details
-							</button>
-							<button
-								class="btn btn-small"
-								@click="viewQuorum(meeting.meetingId)"
-							>
-								Quorum
-							</button>
-						</td>
-					</tr>
-				</tbody>
-			</table>
+		<div v-else class="meeting-card">
+			<div class="meeting-header">
+				<h3>{{ meetingReport.meetingName }}</h3>
+				<p v-if="meetingReport.description" class="description">
+					{{ meetingReport.description }}
+				</p>
+			</div>
 
-			<TablePagination
-				:current-page="currentPage"
-				:total-pages="totalPages"
-				:total-items="totalMeetings"
-				@page-change="goToPage"
-			/>
+			<div class="meeting-details">
+				<div class="detail-row">
+					<span class="detail-label">Start Date:</span>
+					<span class="detail-value">{{
+						formatDate(meetingReport.startDate)
+					}}</span>
+				</div>
+				<div class="detail-row">
+					<span class="detail-label">End Date:</span>
+					<span class="detail-value">{{
+						formatDate(meetingReport.endDate)
+					}}</span>
+				</div>
+				<div class="detail-row">
+					<span class="detail-label">Quorum Pool:</span>
+					<span class="detail-value">{{ meetingReport.quorumPoolName }}</span>
+				</div>
+				<div class="detail-row">
+					<span class="detail-label">Quorum Status:</span>
+					<span class="detail-value">
+						<span
+							v-if="meetingReport.quorumCalledAt !== null"
+							class="status-badge called"
+						>
+							Called
+						</span>
+						<span v-else class="status-badge not-called">Not Called</span>
+					</span>
+				</div>
+				<div class="detail-row">
+					<span class="detail-label">Motions:</span>
+					<span class="detail-value">{{
+						meetingReport.motionSummaries.length
+					}}</span>
+				</div>
+			</div>
+
+			<div class="meeting-actions">
+				<button class="btn btn-primary" @click="viewMeetingDetails">
+					View Details
+				</button>
+				<button class="btn btn-secondary" @click="viewQuorum">
+					View Quorum
+				</button>
+			</div>
 		</div>
 	</div>
 </template>
 
 <style scoped>
 .meeting-list {
-	max-width: 1400px;
+	max-width: 800px;
 	margin: 0 auto;
 }
 
@@ -151,7 +192,7 @@ onMounted(() => {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	margin-bottom: 2rem;
+	margin-bottom: 1.5rem;
 }
 
 .header h2 {
@@ -182,46 +223,53 @@ onMounted(() => {
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
-.table-container {
+.meeting-card {
 	background-color: white;
 	border-radius: 8px;
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-	overflow: hidden;
+	padding: 1.5rem;
 }
 
-.meetings-table {
-	width: 100%;
-	border-collapse: collapse;
+.meeting-header {
+	border-bottom: 1px solid #e0e0e0;
+	padding-bottom: 1rem;
+	margin-bottom: 1rem;
 }
 
-.meetings-table th {
-	background-color: #f8f9fa;
-	padding: 1rem;
-	text-align: left;
-	font-weight: 600;
+.meeting-header h3 {
+	margin: 0 0 0.5rem 0;
 	color: #2c3e50;
-	border-bottom: 2px solid #dee2e6;
+	font-size: 1.25rem;
 }
 
-.meetings-table td {
-	padding: 1rem;
-	border-bottom: 1px solid #dee2e6;
+.meeting-header .description {
+	margin: 0;
+	color: #666;
+	font-size: 0.9rem;
 }
 
-.meetings-table tbody tr:hover {
-	background-color: #f8f9fa;
+.meeting-details {
+	margin-bottom: 1.5rem;
 }
 
-.meeting-name {
+.detail-row {
+	display: flex;
+	padding: 0.5rem 0;
+	border-bottom: 1px solid #f0f0f0;
+}
+
+.detail-row:last-child {
+	border-bottom: none;
+}
+
+.detail-label {
 	font-weight: 500;
-	color: #2c3e50;
+	color: #666;
+	min-width: 120px;
 }
 
-.description {
-	max-width: 200px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+.detail-value {
+	color: #2c3e50;
 }
 
 .status-badge {
@@ -242,15 +290,14 @@ onMounted(() => {
 	color: #ef6c00;
 }
 
-.actions-cell {
+.meeting-actions {
 	display: flex;
-	gap: 0.5rem;
+	gap: 0.75rem;
 	flex-wrap: wrap;
-	align-items: center;
 }
 
 .btn {
-	padding: 0.5rem 1rem;
+	padding: 0.625rem 1.25rem;
 	border: none;
 	border-radius: 4px;
 	cursor: pointer;
@@ -259,21 +306,65 @@ onMounted(() => {
 	text-decoration: none;
 	display: inline-block;
 	transition: all 0.2s;
+}
+
+.btn-primary {
 	background-color: #34495e;
 	color: white;
 }
 
-.btn:hover {
+.btn-primary:hover {
 	background-color: #2c3e50;
 }
 
-.btn-small {
-	padding: 0.25rem 0.75rem;
-	font-size: 0.8125rem;
+.btn-secondary {
+	background-color: #6c757d;
+	color: white;
+}
+
+.btn-secondary:hover {
+	background-color: #5a6268;
+}
+
+.btn-change {
+	background-color: transparent;
+	color: #34495e;
+	border: 1px solid #34495e;
+}
+
+.btn-change:hover:not(:disabled) {
+	background-color: #34495e;
+	color: white;
 }
 
 .btn:disabled {
 	opacity: 0.5;
 	cursor: not-allowed;
+}
+
+@media (max-width: 600px) {
+	.header {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 1rem;
+	}
+
+	.detail-row {
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.detail-label {
+		min-width: auto;
+	}
+
+	.meeting-actions {
+		flex-direction: column;
+	}
+
+	.meeting-actions .btn {
+		width: 100%;
+		text-align: center;
+	}
 }
 </style>


### PR DESCRIPTION
## Summary

- **Banner Updates**: Changed "Observer" to "Watcher" for consistent terminology, added meeting indicator showing current meeting name
- **Meeting Focus**: Watchers now see only their joined meeting instead of all meetings
- **Navigation**: Added "Change Meeting" functionality to leave current meeting and select a different one
- **Conditional Nav**: Navigation links only appear after a meeting is selected

## Changes

### WatcherLayout.vue
- Changed banner title from "Observer" to "Watcher"
- Added meeting indicator showing "Observing: [Meeting Name]"
- Added route watcher to update meeting info on navigation
- Added "Change Meeting" button in both desktop and mobile nav
- Navigation links conditionally shown only when meeting is selected

### WatcherMeetingList.vue
- Refactored from table of ALL meetings to card showing ONLY joined meeting
- Shows meeting details: name, description, dates, quorum pool, status, motion count
- Added "Change Meeting", "View Details", and "View Quorum" buttons
- Responsive design for mobile layouts

## Test plan

- [x] Login as watcher user
- [x] Verify meeting selection page shows active and upcoming meetings
- [x] Verify "Current Meeting" nav link NOT shown on selection page
- [x] Select a meeting to observe
- [x] Verify banner shows "MCDC Convention Voting - Watcher"
- [x] Verify banner shows "Observing: [Meeting Name]"
- [x] Verify "Current Meeting" and "Change Meeting" nav links appear
- [x] Verify meetings list shows ONLY the joined meeting
- [x] Click "Change Meeting" and verify redirect to selection
- [x] Verify can select a different meeting
- [x] Test mobile responsive layout
- [x] All lint/type checks pass
- [x] All unit tests pass

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)