### PR TITLE
Add meeting date validation for start/end times (Issue #136)

### DIFF
--- a/packages/client/src/views/admin/MeetingCreate.vue
+++ b/packages/client/src/views/admin/MeetingCreate.vue
@@ -79,6 +79,9 @@ function validateFormData(data: FormDataType): string | null {
 	if (endDate <= startDate) {
 		return "End date must be after start date.";
 	}
+	if (endDate < new Date()) {
+		return "End date cannot be in the past.";
+	}
 	return null;
 }
 

--- a/packages/client/src/views/admin/MeetingEdit.vue
+++ b/packages/client/src/views/admin/MeetingEdit.vue
@@ -86,6 +86,9 @@ const loading = ref(false);
 const saving = ref(false);
 const error = ref<string | null>(null);
 
+// Track original end date to detect changes
+const originalEndDate = ref<string>(EMPTY_STRING);
+
 // Voter pools state
 const selectedVoterPoolIds = ref<Set<number>>(new Set());
 const loadingVoterPools = ref(false);
@@ -188,11 +191,12 @@ async function loadMeeting(): Promise<void> {
 		const response = await getMeeting(meetingId);
 		if (response.data !== undefined) {
 			const { data: meeting } = response;
+			const endDateForInput = formatDateForInput(meeting.endDate);
 			formData.value = {
 				name: meeting.name,
 				description: meeting.description ?? EMPTY_STRING,
 				startDate: formatDateForInput(meeting.startDate),
-				endDate: formatDateForInput(meeting.endDate),
+				endDate: endDateForInput,
 				quorumVotingPoolId: String(meeting.quorumVotingPoolId),
 				quorumPercentage: meeting.quorumPercentage,
 				watcherPoolId:
@@ -204,6 +208,8 @@ async function loadMeeting(): Promise<void> {
 						? EMPTY_STRING
 						: String(meeting.meetingAdminPoolId),
 			};
+			// Store original end date to detect changes
+			originalEndDate.value = endDateForInput;
 		}
 	} catch (err) {
 		error.value = err instanceof Error ? err.message : "Failed to load meeting";
@@ -495,6 +501,11 @@ function validateFormData(data: FormDataType): string | null {
 	const endDate = new Date(data.endDate);
 	if (endDate <= startDate) {
 		return "End date must be after start date.";
+	}
+	// Only check "not in past" if end date was changed
+	const endDateWasChanged = data.endDate !== originalEndDate.value;
+	if (endDateWasChanged && endDate < new Date()) {
+		return "End date cannot be set to a time in the past.";
 	}
 	return null;
 }

--- a/packages/server/src/services/meeting-service.ts
+++ b/packages/server/src/services/meeting-service.ts
@@ -63,6 +63,33 @@ const VALID_STATUS_TRANSITIONS: Record<MotionStatus, MotionStatus[]> = {
 // ============================================================================
 
 /**
+ * Validate meeting date constraints
+ * - Start date must be before end date
+ * - End date cannot be set to a time in the past
+ */
+function validateMeetingDates(
+	startDate: Date,
+	endDate: Date,
+	isEndDateBeingUpdated = true,
+): void {
+	// Start date must be before end date
+	if (endDate <= startDate) {
+		throw new ServiceError(
+			ServiceErrorCode.INVALID_INPUT,
+			"End date must be after start date.",
+		);
+	}
+
+	// End date cannot be set to a time in the past
+	if (isEndDateBeingUpdated && endDate < new Date()) {
+		throw new ServiceError(
+			ServiceErrorCode.INVALID_INPUT,
+			"End date cannot be set to a time in the past.",
+		);
+	}
+}
+
+/**
  * Verify a pool exists, throw error if not
  */
 async function verifyPoolExists(
@@ -140,6 +167,9 @@ export async function createMeeting(
 		quorumVotingPoolId,
 		quorumPercentage,
 	} = request;
+
+	// Validate meeting dates
+	validateMeetingDates(new Date(startDate), new Date(endDate));
 
 	// Verify quorum pool exists
 	await verifyPoolExists(quorumVotingPoolId, "Pool");
@@ -508,6 +538,30 @@ export async function updateMeeting(
 			ServiceErrorCode.INVALID_INPUT,
 			"No fields to update",
 		);
+	}
+
+	// Validate dates if either is being updated
+	if (updates.startDate !== undefined || updates.endDate !== undefined) {
+		// Get current meeting to compare dates
+		const currentMeeting = await getMeetingById(meetingId);
+		if (currentMeeting === null) {
+			throw new ServiceError(
+				ServiceErrorCode.MEETING_NOT_FOUND,
+				`Meeting with ID ${String(meetingId)} not found`,
+			);
+		}
+
+		const newStartDate =
+			updates.startDate === undefined
+				? currentMeeting.startDate
+				: new Date(updates.startDate);
+		const newEndDate =
+			updates.endDate === undefined
+				? currentMeeting.endDate
+				: new Date(updates.endDate);
+		const isEndDateBeingUpdated = updates.endDate !== undefined;
+
+		validateMeetingDates(newStartDate, newEndDate, isEndDateBeingUpdated);
 	}
 
 	// Add updated_at


### PR DESCRIPTION
## Summary
- Adds validation ensuring end date is chronologically after start date
- Prevents setting end date to a time in the past when creating or updating meetings
- Allows existing past end dates to remain unchanged during edits (only validates when value changes)
- Implements validation on both server-side and client-side for immediate user feedback

## Test plan
- [x] Create meeting with end date before start date → error shown
- [x] Create meeting with end date in the past → error shown
- [x] Create meeting with valid future dates → succeeds
- [x] Edit meeting, change start date to after end date → error shown
- [x] Edit meeting, change end date to past time → error shown
- [x] Edit meeting, leave existing dates unchanged → succeeds
- [x] All lint/format/type checks pass
- [x] All unit tests pass

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)