### PR TITLE
Add numbered choice display with proper spacing in projector (Issue #137)

### DIFF
--- a/packages/client/src/views/admin/ProjectorControl.vue
+++ b/packages/client/src/views/admin/ProjectorControl.vue
@@ -928,11 +928,11 @@ onUnmounted(() => {
 							</p>
 							<div v-if="motionChoices.length > 0" class="motion-choices">
 								<div
-									v-for="choice in motionChoices"
+									v-for="(choice, index) in motionChoices"
 									:key="choice.id"
 									class="motion-choice"
 								>
-									{{ choice.name }}
+									{{ index + 1 }}. {{ choice.name }}
 								</div>
 							</div>
 						</div>

--- a/packages/client/src/views/admin/ProjectorDisplay.vue
+++ b/packages/client/src/views/admin/ProjectorDisplay.vue
@@ -350,8 +350,12 @@ onUnmounted(() => {
 					{{ motion.description }}
 				</p>
 				<div v-if="choices.length > 0" class="choices">
-					<div v-for="choice in choices" :key="choice.id" class="choice">
-						{{ choice.name }}
+					<div
+						v-for="(choice, index) in choices"
+						:key="choice.id"
+						class="choice"
+					>
+						{{ index + 1 }}. {{ choice.name }}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- Adds sequential numbering to choices in projector views (e.g., "1. Choice Name", "2. Choice Name")
- Proper spacing between number and choice name for readability
- Applied to both full-screen ProjectorDisplay and ProjectorControl preview panel

## Test plan
- [x] Verify numbered choices display correctly in projector preview panel
- [x] Verify numbered choices display correctly in full-screen projector display
- [x] All lint/format/type checks pass
- [x] All unit tests pass

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)