### PR TITLE
Add Projector Control access for Meeting Admins (Issue #138)

### DIFF
--- a/packages/client/src/views/AdminLayout.vue
+++ b/packages/client/src/views/AdminLayout.vue
@@ -180,6 +180,13 @@ onUnmounted(() => {
 					>
 						Leave Meeting
 					</a>
+					<RouterLink
+						v-if="isMeetingAdmin && isJoined"
+						to="/admin/projector"
+						class="dropdown-link"
+					>
+						Projector Control
+					</RouterLink>
 				</NavDropdown>
 				<NavDropdown v-if="isAdmin" label="System">
 					<RouterLink to="/admin/system" class="dropdown-link">
@@ -305,6 +312,14 @@ onUnmounted(() => {
 					>
 						Leave Meeting
 					</a>
+					<RouterLink
+						v-if="isMeetingAdmin && isJoined"
+						to="/admin/projector"
+						class="mobile-nav-link"
+						@click="closeNav"
+					>
+						Projector Control
+					</RouterLink>
 				</div>
 
 				<!-- System section (global admins only) -->


### PR DESCRIPTION
## Summary
- Adds Projector Control link to Meetings dropdown for Meeting Admins when focused on a meeting
- Link visible in both desktop navigation and mobile hamburger menu
- Projector is automatically locked to the focused meeting (existing behavior)
- Available before, during, and after meeting times as requested

## Test plan
- [x] Verify Projector Control link hidden before joining a meeting
- [x] Verify link appears in Meetings dropdown after joining (desktop)
- [x] Verify link appears in Meetings section (mobile menu)
- [x] Verify projector control opens and is locked to focused meeting
- [x] Verify projector functionality works (modes, display window, etc.)
- [x] Verify link disappears after leaving meeting
- [x] All lint/format/type checks pass
- [x] All unit tests pass

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)